### PR TITLE
fix(auto-form): 收宽 calendarDate 控件类型修复声明发射 TS2883

### DIFF
--- a/src/runtime/domains/auto-form/controls.ts
+++ b/src/runtime/domains/auto-form/controls.ts
@@ -61,7 +61,8 @@ const DEFAULT_CONTROL_COMPONENTS = {
   boolean: UCheckbox,
   enum: USelect,
   file: UFileUpload,
-  calendarDate: DatePicker,
+  // reka-ui 未公开导出 Calendar 相关类型，收宽避免声明发射 TS2883（详见 AGENTS.md）
+  calendarDate: DatePicker as IsComponent,
   inputDate: UInputDate,
   inputTime: UInputTime,
 


### PR DESCRIPTION
## 背景

`pnpm run build`（`nuxt-module-build build` → mkdist）在声明发射阶段失败：

```
src/runtime/domains/auto-form/controls.ts(58,7): error TS2883:
The inferred type of 'DEFAULT_CONTROL_COMPONENTS' cannot be named without a reference to
'Matcher' / 'WeekDayFormat' / 'WeekStartsOn' from 'node_modules/reka-ui/dist/index2'.
```

mkdist 会为每个顶层声明（含未导出的 `DEFAULT_CONTROL_COMPONENTS`）生成 `.d.ts`。`DatePicker` 透传 `@nuxt/ui` 的 `CalendarProps`，把 reka-ui 内部未公开导出的 `Matcher`/`WeekDayFormat`/`WeekStartsOn` 带入推断类型，无法可移植命名（TS2883），在 `build` 阶段从告警升级为硬错误，阻断构建。AGENTS.md 已记录该上游约束。

## 改动

将 `DEFAULT_CONTROL_COMPONENTS.calendarDate` 单点收宽为 `IsComponent`（仓库既有的宽组件标记类型），切断对 reka-ui 内部类型的引用。仅 `DatePicker` 引用 Calendar 类型，单点收宽即可消除全部三条 TS2883。

- 运行时值不变，键字面量保持不变，仅 `calendarDate` 值类型从 `typeof DatePicker` 收宽
- `IsComponent` 即 `AutoFormControl` 默认泛型参数，对 `DEFAULT_CONTROLS` 公开类型与 `useAutoForm` 完全兼容
- 双模式共享文件，运行时无差异，无需同步其它面

## 测试计划

- [x] `pnpm run build` 通过，`dist/` 正常产出，TS2883 消除
- [x] `pnpm dev:vue:build` 通过（Vue 模式回归）
- [x] `pnpm typecheck` src + playgrounds/play 通过（docs 的 `TS7053` 为改动前既有、与本修复无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)