### PR TITLE
fix(data-table): resizable 列保持自适应并修正特殊列勾选框对齐

### DIFF
--- a/src/runtime/components/DataTable.vue
+++ b/src/runtime/components/DataTable.vue
@@ -17,7 +17,7 @@ import type { TableData, TableProps, ComponentConfig } from '@nuxt/ui'
 import { UTable } from '#components'
 import { useAppConfig } from '#imports'
 import type { Ref, WritableComputedRef } from 'vue'
-import { computed, nextTick, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import { useExtendedTv } from '../utils/extend-theme'
 import { resolveColumns } from '../domains/data-table/columns/resolve-columns'
 import { resolveCallbackValue } from '../domains/data-table/columns/utils'
@@ -280,49 +280,6 @@ function scrollToTop(options: ScrollToOptions = { top: 0, behavior: 'smooth' }) 
 const tableApi = computed<Table<T> | null>(() => tableRef.value?.tableApi ?? null)
 const isColumnResizing = computed(() => Boolean(tableApi.value?.getState().columnSizingInfo.isResizingColumn))
 
-const resizableEnabled = computed(() => !!props.resizable || resolved.value.hasColumnResizing)
-
-// resizable 列首次有数据后测量各列内容宽写入 columnSizing：列宽权威化（配合 w-fit）
-// 后拖拽稳定、起点为内容宽、纯点击不改宽。仅补未显式 size 且未在 sizing 中的可调整列。
-let widthsMeasured = false
-function measureColumnWidths(): void {
-  const tableEl = tableRef.value?.tableRef
-  const api = tableApi.value
-  if (!tableEl || !api) return
-  const headerRows = tableEl.querySelectorAll('thead tr')
-  const leafRow = headerRows[headerRows.length - 1]
-  if (!leafRow) return
-  const cells = Array.from(leafRow.children) as HTMLElement[]
-  const current = effectiveSizing.value
-  const seed: Record<string, number> = { ...current }
-  let changed = false
-  api.getVisibleLeafColumns().forEach((column, i) => {
-    const cell = cells[i]
-    if (!cell || !column.getCanResize() || column.columnDef.size != null || column.id in current) return
-    const w = Math.round(cell.getBoundingClientRect().width)
-    if (w <= 0) return
-    seed[column.id] = w
-    changed = true
-  })
-  if (changed) effectiveSizing.value = seed
-}
-
-function scheduleMeasure(): void {
-  if (widthsMeasured || !resizableEnabled.value) return
-  if (!tableApi.value?.getRowModel().rows.length) return
-  nextTick(() => {
-    measureColumnWidths()
-    widthsMeasured = true
-  })
-}
-
-onMounted(scheduleMeasure)
-watch(() => tableApi.value?.getRowModel().rows.length ?? 0, scheduleMeasure)
-watch(() => resolved.value.allColumnIds, () => {
-  widthsMeasured = false
-  scheduleMeasure()
-}, { flush: 'post' })
-
 const isTreeMode = computed(() => Boolean(props.childrenKey))
 
 const treeMaxDepth = computed(() => {
@@ -407,8 +364,7 @@ const { baseUi, extraUi } = useExtendedTv(
       wrapper: [props.ui?.wrapper, props.class]
     },
     variants: {
-      // 开启 resizable 时走 w-fit：表宽=各列宽之和、无 slack 重排，单列设宽权威生效、拖拽稳定
-      fitContent: !!props.fitContent || resizableEnabled.value,
+      fitContent: !!props.fitContent,
       bordered: !!props.bordered,
       striped: !!props.stripe,
       tree: isTreeMode.value,

--- a/src/runtime/components/DataTable.vue
+++ b/src/runtime/components/DataTable.vue
@@ -17,7 +17,7 @@ import type { TableData, TableProps, ComponentConfig } from '@nuxt/ui'
 import { UTable } from '#components'
 import { useAppConfig } from '#imports'
 import type { Ref, WritableComputedRef } from 'vue'
-import { computed, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import { useExtendedTv } from '../utils/extend-theme'
 import { resolveColumns } from '../domains/data-table/columns/resolve-columns'
 import { resolveCallbackValue } from '../domains/data-table/columns/utils'
@@ -280,6 +280,49 @@ function scrollToTop(options: ScrollToOptions = { top: 0, behavior: 'smooth' }) 
 const tableApi = computed<Table<T> | null>(() => tableRef.value?.tableApi ?? null)
 const isColumnResizing = computed(() => Boolean(tableApi.value?.getState().columnSizingInfo.isResizingColumn))
 
+const resizableEnabled = computed(() => !!props.resizable || resolved.value.hasColumnResizing)
+
+// resizable 列首次有数据后测量各列内容宽写入 columnSizing：列宽权威化（配合 w-fit）
+// 后拖拽稳定、起点为内容宽、纯点击不改宽。仅补未显式 size 且未在 sizing 中的可调整列。
+let widthsMeasured = false
+function measureColumnWidths(): void {
+  const tableEl = tableRef.value?.tableRef
+  const api = tableApi.value
+  if (!tableEl || !api) return
+  const headerRows = tableEl.querySelectorAll('thead tr')
+  const leafRow = headerRows[headerRows.length - 1]
+  if (!leafRow) return
+  const cells = Array.from(leafRow.children) as HTMLElement[]
+  const current = effectiveSizing.value
+  const seed: Record<string, number> = { ...current }
+  let changed = false
+  api.getVisibleLeafColumns().forEach((column, i) => {
+    const cell = cells[i]
+    if (!cell || !column.getCanResize() || column.columnDef.size != null || column.id in current) return
+    const w = Math.round(cell.getBoundingClientRect().width)
+    if (w <= 0) return
+    seed[column.id] = w
+    changed = true
+  })
+  if (changed) effectiveSizing.value = seed
+}
+
+function scheduleMeasure(): void {
+  if (widthsMeasured || !resizableEnabled.value) return
+  if (!tableApi.value?.getRowModel().rows.length) return
+  nextTick(() => {
+    measureColumnWidths()
+    widthsMeasured = true
+  })
+}
+
+onMounted(scheduleMeasure)
+watch(() => tableApi.value?.getRowModel().rows.length ?? 0, scheduleMeasure)
+watch(() => resolved.value.allColumnIds, () => {
+  widthsMeasured = false
+  scheduleMeasure()
+}, { flush: 'post' })
+
 const isTreeMode = computed(() => Boolean(props.childrenKey))
 
 const treeMaxDepth = computed(() => {
@@ -364,7 +407,8 @@ const { baseUi, extraUi } = useExtendedTv(
       wrapper: [props.ui?.wrapper, props.class]
     },
     variants: {
-      fitContent: !!props.fitContent,
+      // 开启 resizable 时走 w-fit：表宽=各列宽之和、无 slack 重排，单列设宽权威生效、拖拽稳定
+      fitContent: !!props.fitContent || resizableEnabled.value,
       bordered: !!props.bordered,
       striped: !!props.stripe,
       tree: isTreeMode.value,

--- a/src/runtime/domains/data-table/columns/resolve-data-column.ts
+++ b/src/runtime/domains/data-table/columns/resolve-data-column.ts
@@ -163,11 +163,47 @@ export function renderHeaderActions<T>(
   const leading = actions.filter(a => a.position === 'leading').map(a => a.render(ctx))
   const trailing = actions.filter(a => a.position === 'trailing').map(a => a.render(ctx))
 
+  // 抓住拖动线时仅给当前列种入真实渲染宽（getSize 立即权威），避免 TanStack 取默认宽 150 造成 snap/起拖抖动；
+  // 纯点击（未实际拖动）松手后回滚该条目，使列回到自适应。
+  const startResize = (e: MouseEvent | TouchEvent): void => {
+    const id = ctx.column.id
+    const seeded = !(id in ctx.table.getState().columnSizing)
+    if (seeded) {
+      const th = (e.currentTarget as HTMLElement | null)?.closest('th')
+      const w = th ? Math.round(th.getBoundingClientRect().width) : 0
+      if (w > 0) ctx.table.setColumnSizing(prev => ({ ...prev, [id]: w }))
+    }
+    ctx.header.getResizeHandler()(e)
+    if (!seeded) return
+
+    const startX = 'touches' in e ? e.touches[0]?.clientX ?? 0 : e.clientX
+    let moved = false
+    const onMove = (ev: MouseEvent | TouchEvent): void => {
+      const x = 'touches' in ev ? ev.touches[0]?.clientX : ev.clientX
+      if (typeof x === 'number' && Math.abs(x - startX) > 2) moved = true
+    }
+    const onEnd = (): void => {
+      if (!moved) {
+        ctx.table.setColumnSizing(prev =>
+          Object.fromEntries(Object.entries(prev).filter(([key]) => key !== id))
+        )
+      }
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onEnd)
+      window.removeEventListener('touchmove', onMove)
+      window.removeEventListener('touchend', onEnd)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onEnd)
+    window.addEventListener('touchmove', onMove)
+    window.addEventListener('touchend', onEnd)
+  }
+
   const resizeHandle = resizable
     ? h('div', {
         class: 'absolute top-0 bottom-0 right-0 w-4 -mr-2 cursor-col-resize select-none touch-none flex items-center justify-center group/resize',
-        onMousedown: ctx.header.getResizeHandler(),
-        onTouchstart: ctx.header.getResizeHandler(),
+        onMousedown: startResize,
+        onTouchstart: startResize,
         onClick: (e: Event) => e.stopPropagation()
       }, [
         h('div', {

--- a/src/runtime/domains/data-table/columns/resolve-data-column.ts
+++ b/src/runtime/domains/data-table/columns/resolve-data-column.ts
@@ -163,55 +163,11 @@ export function renderHeaderActions<T>(
   const leading = actions.filter(a => a.position === 'leading').map(a => a.render(ctx))
   const trailing = actions.filter(a => a.position === 'trailing').map(a => a.render(ctx))
 
-  // table-auto 下仅固定被拖列、其余列自适应会在拖拽中持续重排导致抖动。
-  // 拖拽起始时把全部自适应列按当前真实渲染宽测量并锁定（整表固定，拖拽平滑、起始无跳变）；
-  // 松手后释放本次临时锁定的未拖列，使其回到自适应，仅保留被拖列的固定宽。
-  const startResize = (event: Event): void => {
-    const th = (event.target as HTMLElement).closest('th')
-    const tr = th?.closest('tr')
-    const draggedId = ctx.column.id
-    const tempIds: string[] = []
-
-    if (tr) {
-      const sizing = ctx.table.getState().columnSizing
-      const cells = Array.from(tr.children) as HTMLElement[]
-      const leafHeaders = ctx.table.getHeaderGroups().at(-1)?.headers ?? []
-      const seed: Record<string, number> = { ...sizing }
-
-      leafHeaders.forEach((header, i) => {
-        const { column } = header
-        const cell = cells[i]
-        if (!cell || column.id in sizing || column.columnDef.size != null) return
-        const w = Math.round(cell.getBoundingClientRect().width)
-        if (w <= 0) return
-        seed[column.id] = w
-        if (column.id !== draggedId) tempIds.push(column.id)
-      })
-
-      ctx.table.setColumnSizing(seed)
-    }
-
-    if (tempIds.length > 0) {
-      const tempSet = new Set(tempIds)
-      const release = (): void => {
-        ctx.table.setColumnSizing(prev =>
-          Object.fromEntries(Object.entries(prev).filter(([id]) => !tempSet.has(id)))
-        )
-        window.removeEventListener('mouseup', release)
-        window.removeEventListener('touchend', release)
-      }
-      window.addEventListener('mouseup', release)
-      window.addEventListener('touchend', release)
-    }
-
-    ctx.header.getResizeHandler()(event)
-  }
-
   const resizeHandle = resizable
     ? h('div', {
         class: 'absolute top-0 bottom-0 right-0 w-4 -mr-2 cursor-col-resize select-none touch-none flex items-center justify-center group/resize',
-        onMousedown: startResize,
-        onTouchstart: startResize,
+        onMousedown: ctx.header.getResizeHandler(),
+        onTouchstart: ctx.header.getResizeHandler(),
         onClick: (e: Event) => e.stopPropagation()
       }, [
         h('div', {

--- a/src/runtime/domains/data-table/columns/resolve-data-column.ts
+++ b/src/runtime/domains/data-table/columns/resolve-data-column.ts
@@ -163,13 +163,47 @@ export function renderHeaderActions<T>(
   const leading = actions.filter(a => a.position === 'leading').map(a => a.render(ctx))
   const trailing = actions.filter(a => a.position === 'trailing').map(a => a.render(ctx))
 
-  // 自适应列拖拽前先测量真实渲染宽写入 columnSizing，使起始宽=实测宽，避免从默认 size 跳变。
+  // table-auto 下仅固定被拖列、其余列自适应会在拖拽中持续重排导致抖动。
+  // 拖拽起始时把全部自适应列按当前真实渲染宽测量并锁定（整表固定，拖拽平滑、起始无跳变）；
+  // 松手后释放本次临时锁定的未拖列，使其回到自适应，仅保留被拖列的固定宽。
   const startResize = (event: Event): void => {
     const th = (event.target as HTMLElement).closest('th')
-    if (th && !(ctx.column.id in ctx.table.getState().columnSizing)) {
-      const w = Math.ceil(th.getBoundingClientRect().width)
-      if (w > 0) ctx.table.setColumnSizing(prev => ({ ...prev, [ctx.column.id]: w }))
+    const tr = th?.closest('tr')
+    const draggedId = ctx.column.id
+    const tempIds: string[] = []
+
+    if (tr) {
+      const sizing = ctx.table.getState().columnSizing
+      const cells = Array.from(tr.children) as HTMLElement[]
+      const leafHeaders = ctx.table.getHeaderGroups().at(-1)?.headers ?? []
+      const seed: Record<string, number> = { ...sizing }
+
+      leafHeaders.forEach((header, i) => {
+        const { column } = header
+        const cell = cells[i]
+        if (!cell || column.id in sizing || column.columnDef.size != null) return
+        const w = Math.round(cell.getBoundingClientRect().width)
+        if (w <= 0) return
+        seed[column.id] = w
+        if (column.id !== draggedId) tempIds.push(column.id)
+      })
+
+      ctx.table.setColumnSizing(seed)
     }
+
+    if (tempIds.length > 0) {
+      const tempSet = new Set(tempIds)
+      const release = (): void => {
+        ctx.table.setColumnSizing(prev =>
+          Object.fromEntries(Object.entries(prev).filter(([id]) => !tempSet.has(id)))
+        )
+        window.removeEventListener('mouseup', release)
+        window.removeEventListener('touchend', release)
+      }
+      window.addEventListener('mouseup', release)
+      window.addEventListener('touchend', release)
+    }
+
     ctx.header.getResizeHandler()(event)
   }
 

--- a/src/runtime/domains/data-table/columns/resolve-data-column.ts
+++ b/src/runtime/domains/data-table/columns/resolve-data-column.ts
@@ -163,11 +163,21 @@ export function renderHeaderActions<T>(
   const leading = actions.filter(a => a.position === 'leading').map(a => a.render(ctx))
   const trailing = actions.filter(a => a.position === 'trailing').map(a => a.render(ctx))
 
+  // 自适应列拖拽前先测量真实渲染宽写入 columnSizing，使起始宽=实测宽，避免从默认 size 跳变。
+  const startResize = (event: Event): void => {
+    const th = (event.target as HTMLElement).closest('th')
+    if (th && !(ctx.column.id in ctx.table.getState().columnSizing)) {
+      const w = Math.ceil(th.getBoundingClientRect().width)
+      if (w > 0) ctx.table.setColumnSizing(prev => ({ ...prev, [ctx.column.id]: w }))
+    }
+    ctx.header.getResizeHandler()(event)
+  }
+
   const resizeHandle = resizable
     ? h('div', {
         class: 'absolute top-0 bottom-0 right-0 w-4 -mr-2 cursor-col-resize select-none touch-none flex items-center justify-center group/resize',
-        onMousedown: ctx.header.getResizeHandler(),
-        onTouchstart: ctx.header.getResizeHandler(),
+        onMousedown: startResize,
+        onTouchstart: startResize,
         onClick: (e: Event) => e.stopPropagation()
       }, [
         h('div', {

--- a/src/runtime/domains/data-table/columns/resolve-special-columns.ts
+++ b/src/runtime/domains/data-table/columns/resolve-special-columns.ts
@@ -67,7 +67,9 @@ function buildSpecialColumnDef<T>(
   ctx.allColumnIds.push(id)
 
   const effectivePinable = col.pinable ?? (options.pinable === true)
-  const effectiveResizable = col.resizable ?? (options.resizable === true)
+  // 特殊列（selection/index/expand/row-pinning/actions）不继承全局 resizable，
+  // 否则表头会被包进 flex + resize handle，导致勾选框与单元格错位；需要时按列显式开启。
+  const effectiveResizable = col.resizable ?? false
 
   ctx.flags.hasPinning ||= effectivePinable
   ctx.flags.hasResizing ||= effectiveResizable

--- a/src/runtime/domains/data-table/columns/style.ts
+++ b/src/runtime/domains/data-table/columns/style.ts
@@ -7,10 +7,13 @@ import { resolvePresetSize } from './utils'
 export function resolveColumnSize<T>(ctx: Header<T, unknown> | Cell<T, unknown>): Record<string, string> {
   const { columnDef } = ctx.column
   const table = ctx.getContext().table
-  const isPinned = ctx.column.getIsPinned()
-  const hasMeasuredSize = isPinned && (ctx.column.id in table.getState().columnSizing)
+  // 固定宽的三种情形：列已 pin（sticky 偏移需具体宽）/ 显式设了 size / 已被测量或拖拽过（进入 columnSizing）。
+  // 仅开启 resizable 但未拖拽的列保持自适应，拖拽起始时再测量真实宽度写入 columnSizing。
+  const isPinned = !!ctx.column.getIsPinned()
+  const isSized = ctx.column.id in table.getState().columnSizing
+  const hasExplicitSize = columnDef.size != table._getDefaultColumnDef().size
 
-  if (hasMeasuredSize || columnDef.size != table._getDefaultColumnDef().size || columnDef.enableResizing === true) {
+  if (isPinned || isSized || hasExplicitSize) {
     const w = `${ctx.column.getSize()}px`
     return { width: w, minWidth: w, maxWidth: w }
   }


### PR DESCRIPTION
## 背景

全局开启 `resizable` 时，消费方（movk-dashboard）发现两处问题：

1. **列宽自适应丢失**：所有未显式设 `size` 的数据列被固定为 TanStack 默认 150px。
2. **selection 勾选框错位**：表头复选框与单元格复选框水平不对齐。

## 根因与修复

- `resolveColumnSize`：原逻辑只要 `enableResizing === true` 即返回固定 `width`，导致未拖拽的列也丢失自适应。改为仅在 **pinned / 显式 size / 已进入 columnSizing** 时固定宽，其余保持自适应。
- resize handle：拖拽起始（`onMousedown/onTouchstart`）先测量真实渲染宽写入 `columnSizing`，使起点 = 实测宽，避免从默认 size 跳变（复用 pin action 既有测量模式）。
- 特殊列（selection/index/expand/row-pinning/actions）默认不再继承全局 `resizable`，避免表头被包进 flex + resize handle 而与单元格错位；需要时仍可按列 `resizable: true` 显式开启。

## 验证

- `eslint` + `vue-tsc --noEmit` 通过。
- 行为：数据列默认随内容自适应，拖拽后固定且无跳变；selection 勾选框表头/单元格对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)