### PR TITLE
fix(auto-form): 清空单选控件后 optional 字段校验报错

### DIFF
--- a/src/runtime/domains/auto-form/provider.ts
+++ b/src/runtime/domains/auto-form/provider.ts
@@ -141,9 +141,12 @@ export function useAutoFormProvider(
       {
         ...wrappedProps,
         'onUpdate:modelValue': (v: any) => {
-          context.setValue(v)
+          // 单选 select/selectMenu 清空时 reka 写入 null，而 optional 字段 schema 仅接受 undefined，
+          // 会导致校验失败（Invalid option）。optional 字段的 null 归一为 undefined。
+          const next = (v === null && field.decorators?.isOptional) ? undefined : v
+          context.setValue(next)
           if (typeof userOnUpdate === 'function') {
-            userOnUpdate(v, context)
+            userOnUpdate(next, context)
           }
         },
         'modelValue': unref(context.value)


### PR DESCRIPTION
## 背景

消费方（movk-dashboard）的搜索表单中，单选 `selectMenu`（`clear: true`）选中某项后点击清除按钮，再次提交搜索会抛出：

```
Invalid option: expected one of "ACTIVE"|"DISABLED"|"LOCKED"|"DELETED"
```

## 根因

reka-ui 的 `ComboboxCancel.handleClick` 在清除时把单选 `modelValue` 写为 `null`（`multiple ? [] : null`）。而项目约定字段一律 `.optional()`，其 schema 为 `T | undefined`，**不接受 `null`**，提交时 `pureSchema` 校验失败。

## 修复

在 AutoForm 控件写回路径（`provider.ts` 的 `onUpdate:modelValue`）中，将 **optional 字段**收到的 `null` 归一为 `undefined`，使清空后能正常通过校验。仅对 `field.decorators.isOptional` 为真的字段生效，不影响 nullable / 非 optional 字段。

## 验证

- `eslint` 通过；`auto-form` 相关测试 17 项全过。
- 行为：清空可清除的单选枚举字段后再次提交，不再报 Invalid option。

🤖 Generated with [Claude Code](https://claude.com/claude-code)