### PR TITLE
fix(date-formatter): 修复 fromISO 无法解析带时区偏移的 ISO 字符串

### DIFF
--- a/src/runtime/composables/useDateFormatter.ts
+++ b/src/runtime/composables/useDateFormatter.ts
@@ -20,7 +20,8 @@ import {
   isToday,
   parseDate,
   parseDateTime,
-  parseZonedDateTime
+  parseZonedDateTime,
+  parseAbsolute
 } from '@internationalized/date'
 import type { DateValue } from '@internationalized/date'
 import type { DateRange } from 'reka-ui'
@@ -50,6 +51,9 @@ export interface DateFormatterOptions {
 
 const DEFAULT_LOCALE = 'zh-CN'
 const DEFAULT_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = { dateStyle: 'medium' }
+
+// 匹配 ISO 末尾的 Z 或 ±HH:mm / ±HHmm 时区偏移
+const ABSOLUTE_RE = /(?:Z|[+-]\d{2}:?\d{2})$/
 
 function safe<T>(fn: () => T, fallback: T): T {
   try { return fn() }
@@ -264,10 +268,10 @@ export function useDateFormatter(options: DateFormatterOptions = {}) {
    */
   function parse(value: string) {
     try {
-      if (value.includes('T')) {
-        return value.includes('[') ? parseZonedDateTime(value) : parseDateTime(value)
-      }
-      return parseDate(value)
+      if (!value.includes('T')) return parseDate(value)
+      if (value.includes('[')) return parseZonedDateTime(value)
+      if (ABSOLUTE_RE.test(value)) return parseAbsolute(value, timeZone)
+      return parseDateTime(value)
     }
     catch {
       return null

--- a/test/composables/useDateFormatter.test.ts
+++ b/test/composables/useDateFormatter.test.ts
@@ -97,6 +97,29 @@ describe('useDateFormatter', () => {
       expect(dateTime).toBeDefined()
       expect(dateTime?.toString()).toContain('2025-11-29T10:30:00')
     })
+
+    it('parse: 解析带时区偏移的 ISO 字符串', () => {
+      const date = formatter.parse('2026-01-23T17:15:22.040205+08:00')
+      expect(date).not.toBeNull()
+      expect(date?.year).toBe(2026)
+      expect(date?.month).toBe(1)
+      expect(date?.day).toBe(23)
+    })
+
+    it('parse: 解析负偏移与 Z 后缀的 ISO 字符串', () => {
+      expect(formatter.parse('2026-01-23T17:15:22-05:00')).not.toBeNull()
+      expect(formatter.parse('2026-01-23T17:15:22Z')).not.toBeNull()
+    })
+
+    it('parse: 解析 IANA 命名时区的 ISO 字符串', () => {
+      const date = formatter.parse('2026-01-23T17:15:22[Asia/Shanghai]')
+      expect(date).not.toBeNull()
+      expect(date?.day).toBe(23)
+    })
+
+    it('parse: 非法字符串返回 null', () => {
+      expect(formatter.parse('not-a-date')).toBeNull()
+    })
   })
 
   describe('工具方法 - 获取日期', () => {


### PR DESCRIPTION
## 问题

`useDateFormatter` 的 `fromISO` 对带时区偏移（`+08:00`）或 `Z` 后缀的 ISO 字符串返回 `null`，例如后端返回的 `2026-01-23T17:15:22.040205+08:00`。

## 根因

`parse()` 仅区分 IANA 命名时区（`[...]`）走 `parseZonedDateTime`，其余含 `T` 的一律走 `parseDateTime`。而 `@internationalized/date` 的 `parseDateTime` 遇到带 `±HH:mm` 偏移或 `Z` 的字符串会主动抛错（提示 Use parseAbsolute() instead），被 `try/catch` 吞掉后返回 null。微秒位数不是问题。

## 修复

新增 `ABSOLUTE_RE` 识别末尾的 `Z` 或时区偏移，改走 `parseAbsolute(value, timeZone)`，把绝对瞬间转换到 formatter 配置的时区。

## 测试

`test/composables/useDateFormatter.test.ts` 新增：带 `+08:00`（含微秒）、负偏移 `-05:00`、`Z`、IANA `[...]`、非法串返回 null 等用例。全部 51 项通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)