### PR TITLE
fix(module): 向 componentDetection 声明组件层使用的 @nuxt/ui 组件

### DIFF
--- a/docs/app/components/content/examples/data-table/columns/DataTableResizableExample.vue
+++ b/docs/app/components/content/examples/data-table/columns/DataTableResizableExample.vue
@@ -6,13 +6,13 @@ const data = makePeople(8)
 
 const columns: DataTableColumn<Person>[] = [
   { accessorKey: 'id', header: '工号' },
-  { accessorKey: 'name', header: '姓名' },
+  { accessorKey: 'name', header: '姓名', minSize: 80 },
   { accessorKey: 'level', header: '职级', resizable: false },
-  { accessorKey: 'address', header: '地址' },
-  { accessorKey: 'bio', header: '个人简介', resizable: true }
+  { accessorKey: 'address', header: '地址', size: 120 },
+  { accessorKey: 'bio', header: '个人简介', size: 150, resizable: true }
 ]
 </script>
 
 <template>
-  <MDataTable :columns="columns" :data="data" />
+  <MDataTable :columns="columns" :data="data" :ui="{ root: 'max-w-3xl' }" />
 </template>

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -43,11 +43,14 @@ export default defineNuxtConfig({
   vite: {
     optimizeDeps: {
       include: [
-        'tailwindcss/colors',
-        'tailwind-variants',
-        'json5',
         '@internationalized/date',
-        'maska/vue'
+        '@tanstack/vue-table',
+        'colortranslator',
+        'json5',
+        'maska/vue',
+        'tailwind-variants',
+        'tailwindcss/colors',
+        'zod'
       ]
     }
   },

--- a/playgrounds/play/nuxt.config.ts
+++ b/playgrounds/play/nuxt.config.ts
@@ -3,7 +3,24 @@ export default defineNuxtConfig({
 
   devtools: { enabled: true },
 
+  ui: {
+    experimental: {
+      componentDetection: true
+    }
+  },
+
   compatibilityDate: 'latest',
+
+  vite: {
+    optimizeDeps: {
+      include: [
+        '@movk/core',
+        '@tanstack/vue-table',
+        'tailwind-variants',
+        'tailwindcss/colors'
+      ]
+    }
+  },
 
   movk: {
     api: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,7 @@ import { kebabCase } from 'scule'
 import { updateSiteConfig } from 'nuxt-site-config/kit'
 import { defaultOptions, getDefaultApiConfig } from './utils/defaults'
 import { addTheme } from './utils/theme'
+import { UI_COMPONENTS } from './utils/ui-components'
 
 export * from './runtime/types'
 
@@ -108,6 +109,19 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.css = nuxt.options.css || []
     nuxt.options.css.push(resolve('runtime/index.css'))
+
+    // movk 组件层内部渲染、但消费方通常不会直接书写的 @nuxt/ui 组件,需向 componentDetection 声明,
+    // 否则其主题类(如 Table 的 min-w-full)不会被 @source 扫描生成。复用组件层导入清单,去 U 前缀。
+    const movkUiDeps = UI_COMPONENTS.map(name => name.slice(1))
+    const uiOptions = (nuxt as NuxtWithExtra).options
+    const ui = (uiOptions.ui ??= {})
+    const experimental = (ui.experimental ??= {})
+    const detection = experimental.componentDetection
+    if (detection === true) {
+      experimental.componentDetection = movkUiDeps
+    } else if (Array.isArray(detection)) {
+      experimental.componentDetection = [...new Set([...detection, ...movkUiDeps])]
+    }
 
     const componentIgnore: string[] = []
     if (options.theme?.enabled === false) {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -26,15 +26,7 @@ export interface MovkUIOptions extends Pick<ModuleOptions, 'prefix' | 'theme'> {
 
 export const runtimeDir = normalize(fileURLToPath(new URL('./runtime', import.meta.url)))
 
-/** movk 组件层从 `#components` 具名导入的 @nuxt/ui 组件（去 U 前缀映射到 @nuxt/ui/components/<Name>.vue） */
-export const UI_COMPONENTS = [
-  'UAccordion',
-  'UButton', 'UBadge', 'UCheckbox', 'UCollapsible', 'UForm', 'UDropdownMenu', 'UIcon', 'UInput',
-  'UModal', 'UPagination', 'USelect', 'UPopover', 'UCalendar', 'UColorPicker', 'UTable', 'UFormField',
-  'UTooltip', 'UInputNumber', 'USwitch', 'UTextarea', 'USlider', 'UPinInput', 'UInputTags',
-  'UFileUpload', 'USelectMenu', 'UInputMenu', 'UCheckboxGroup', 'URadioGroup', 'UInputDate',
-  'UInputTime', 'UListbox'
-] as const
+export { UI_COMPONENTS } from './utils/ui-components'
 
 /** movk 在 vue 模式自动导入的非服务端 composables 及其公开导出（排除 API 域），对齐 Nuxt addImportsDir 的导出面 */
 const MOVK_COMPOSABLES: Record<string, readonly string[]> = {

--- a/src/utils/ui-components.ts
+++ b/src/utils/ui-components.ts
@@ -1,0 +1,9 @@
+/** movk 组件层从 `#components` 具名导入的 @nuxt/ui 组件（去 U 前缀映射到 @nuxt/ui/components/<Name>.vue） */
+export const UI_COMPONENTS = [
+  'UAccordion',
+  'UButton', 'UBadge', 'UCheckbox', 'UCollapsible', 'UForm', 'UDropdownMenu', 'UIcon', 'UInput',
+  'UModal', 'UPagination', 'USelect', 'UPopover', 'UCalendar', 'UColorPicker', 'UTable', 'UFormField',
+  'UTooltip', 'UInputNumber', 'USwitch', 'UTextarea', 'USlider', 'UPinInput', 'UInputTags',
+  'UFileUpload', 'USelectMenu', 'UInputMenu', 'UCheckboxGroup', 'URadioGroup', 'UInputDate',
+  'UInputTime', 'UListbox'
+] as const


### PR DESCRIPTION
## 背景

消费方开启 `ui.experimental.componentDetection` 后,@nuxt/ui 仅为「应用层源码中直接书写过的 `<U*>`」生成 `@source "./ui/<x>.ts"`,其扫描显式忽略 `node_modules/**`。movk 组件层内部渲染的 @nuxt/ui 组件(如 `MDataTable` 内的 `UTable`)因此不被检测到,导致这些组件的主题类(如 Table 的 `min-w-full`、`overflow-clip`)缺失 `@source` 而不生成 CSS,表格无法撑满。

## 改动

`src/module.ts`:复用组件层导入清单 `UI_COMPONENTS`(去 `U` 前缀)并入 `nuxt.options.ui.experimental.componentDetection`,仅在消费方启用检测(`true` 或数组)时增补;`false` / 未设置保持不变。

## 验证

- `pnpm lint` / `pnpm typecheck` / `pnpm build` 均通过。
- 消费端升级后 `.nuxt/ui.css` 应出现 `@source "./ui/table.ts"` 等条目,`.min-w-full` 规则恢复生成。