### PR TITLE
fix(data-table): 修复固定列缺少不透明背景与滚动边界阴影

### DIFF
--- a/playgrounds/play/app/pages/data-table/columns.vue
+++ b/playgrounds/play/app/pages/data-table/columns.vue
@@ -100,6 +100,8 @@ tooltip:   (ctx) => ctx.column.id === 'address'`
       <MDataTable
         :columns="fixedColumns"
         :data="data"
+        bordered
+        stripe
         :ui="{ root: 'max-w-2xl' }"
       />
     </Showcase>

--- a/src/runtime/components/DataTable.vue
+++ b/src/runtime/components/DataTable.vue
@@ -18,6 +18,7 @@ import { UTable } from '#components'
 import { useAppConfig } from '#imports'
 import type { Ref, WritableComputedRef } from 'vue'
 import { computed, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
+import { useResizeObserver, useScroll } from '@vueuse/core'
 import { useExtendedTv } from '../utils/extend-theme'
 import { resolveColumns } from '../domains/data-table/columns/resolve-columns'
 import { resolveCallbackValue } from '../domains/data-table/columns/utils'
@@ -248,6 +249,13 @@ const tableRef = useTemplateRef<{
   tableApi: Table<T>
   tableRef: HTMLTableElement | null
 }>('tableRef')
+
+// 横向滚动感知:固定列浮于滚动内容之上时显隐边界阴影(tableRef.$el 为 UTable 的 overflow-auto 滚动根)
+const scrollTarget = () => tableRef.value?.$el ?? null
+const { arrivedState, measure } = useScroll(scrollTarget, { offset: { left: 1, right: 1 } })
+const pinStart = computed(() => !arrivedState.left)
+const pinEnd = computed(() => !arrivedState.right)
+useResizeObserver(scrollTarget, () => measure())
 
 const internalLoading = ref(false)
 
@@ -590,7 +598,12 @@ defineExpose<DataTableExposed<T>>({
 </script>
 
 <template>
-  <div :class="extraUi.wrapper" data-slot="wrapper">
+  <div
+    :class="extraUi.wrapper"
+    data-slot="wrapper"
+    :data-pin-start="pinStart || undefined"
+    :data-pin-end="pinEnd || undefined"
+  >
     <UTable
       :key="tableResetKey"
       ref="tableRef"

--- a/src/theme/data-table.ts
+++ b/src/theme/data-table.ts
@@ -4,6 +4,21 @@ const PINNED_L = 'data-[pinned=left]'
 const NOT_LAST_NOT_PIN = 'not-last:not-data-[pinned=left]:not-data-[pinned=right]'
 const GROUP_HEADER = '[[data-slot=tr]:has([colspan])>&]'
 
+// 真正固定的列(左/右),区别于非固定列的 data-pinned="false"
+const PIN = '&:is([data-pinned=left],[data-pinned=right])'
+// 非固定的普通列,保留半透明行底色以适配任意容器背景
+const NOT_PIN = '&[data-pinned]:not([data-pinned=left]):not([data-pinned=right])'
+// 行状态下固定列的不透明底色,与半透明版同色但混入 --ui-bg 防止横向滚动透出
+const PIN_BG_SELECTED = `[[data-selected=true]>${PIN}]:bg-[color:color-mix(in_oklab,var(--ui-bg-elevated)_50%,var(--ui-bg))]`
+const PIN_BG_HOVER = `[[data-slot=tr][data-selectable=true]:hover>${PIN}]:bg-[color:color-mix(in_oklab,var(--ui-bg-elevated)_50%,var(--ui-bg))]`
+const NOT_PIN_BG_SELECTED = `[[data-selected=true]>${NOT_PIN}]:bg-[color:color-mix(in_oklab,var(--ui-bg-elevated)_50%,transparent)]`
+// 固定列柔和分隔阴影色,可经 --m-dt-pin-shadow-color 覆盖
+const PIN_SHADOW_COLOR = `[${PIN}]:[--m-dt-pin-shadow-color:color-mix(in_oklab,var(--ui-text-muted)_25%,transparent)]`
+// 横向滚动到左侧下方时,最后一个左固定列浮出右向阴影
+const PIN_L_EDGE = `[[data-pin-start]_&[data-pinned=left]:not(:has(+[data-pinned=left]))]:[--m-dt-pin-shadow:8px_0_10px_-8px_var(--m-dt-pin-shadow-color)]`
+// 横向滚动到右侧下方时,第一个右固定列浮出左向阴影
+const PIN_R_EDGE = `[[data-pin-end]_:not([data-pinned=right])+&[data-pinned=right]]:[--m-dt-pin-shadow:-8px_0_10px_-8px_var(--m-dt-pin-shadow-color)]`
+
 const BW = 'var(--m-dt-border-width,1px)'
 const BC = 'var(--m-dt-border-color,var(--ui-border))'
 const BS = 'var(--m-dt-border-style,solid)'
@@ -15,17 +30,27 @@ export default () => ({
     tbody: 'divide-y-0',
     th: [
       `${PINNED}:sticky`,
+      `[${PIN}]:bg-default`,
+      PIN_SHADOW_COLOR,
       `${PINNED}:[--m-dt-pin-shadow:0_0_0_0_transparent]`,
-      `${PINNED}:shadow-[var(--m-dt-pin-shadow)]`
+      `${PINNED}:shadow-[var(--m-dt-pin-shadow)]`,
+      PIN_L_EDGE,
+      PIN_R_EDGE
     ].join(' '),
     td: [
       'empty:p-0',
       `${ROW_SEP}:border-t`,
       `${ROW_SEP}:border-default`,
       `${PINNED}:sticky`,
+      `[${PIN}]:bg-default`,
+      PIN_SHADOW_COLOR,
       `${PINNED}:[--m-dt-pin-shadow:0_0_0_0_transparent]`,
       `${PINNED}:shadow-[var(--m-dt-pin-shadow)]`,
-      '[[data-selected=true]>&[data-pinned]]:bg-[color:color-mix(in_oklab,var(--ui-bg-elevated)_50%,transparent)]'
+      PIN_L_EDGE,
+      PIN_R_EDGE,
+      NOT_PIN_BG_SELECTED,
+      PIN_BG_SELECTED,
+      PIN_BG_HOVER
     ].join(' ')
   },
   variants: {
@@ -64,7 +89,10 @@ export default () => ({
     },
     striped: {
       true: {
-        td: '[[data-slot=tr]:nth-child(even)>&[data-pinned]]:bg-[color:color-mix(in_oklab,var(--ui-bg-accented)_10%,transparent)]'
+        td: [
+          `[[data-slot=tr]:nth-child(even)>${NOT_PIN}]:bg-[color:color-mix(in_oklab,var(--ui-bg-accented)_10%,transparent)]`,
+          `[[data-slot=tr]:nth-child(even)>${PIN}]:bg-[color:color-mix(in_oklab,var(--ui-bg-accented)_10%,var(--ui-bg))]`
+        ].join(' ')
       }
     },
     tree: {


### PR DESCRIPTION
## 概述

修复 MDataTable 固定列在横向滚动时透出下层内容(看起来没有背景色)、且缺少可分辨固定边界阴影的问题。

## 根因

- `@nuxt/ui` table 主题给固定列的是半透明背景 `bg-default/75`,横向滚动时 25% 透明度让下层内容透出。
- movk 主题默认把 `--m-dt-pin-shadow` 设为透明,仅 `bordered` 模式有 1px 边线,默认模式无分隔阴影。

## 改动

- **src/theme/data-table.ts**:为真正固定列(`data-pinned=left/right`)补不透明背景;`striped`/`selected`/`hover` 状态固定列底色混入 `var(--ui-bg)`;非固定列(`data-pinned="false"`)保留半透明以适配任意容器背景;新增滚动感知边界阴影,经 `--m-dt-pin-shadow-color` 可覆盖,`bordered` 模式自动复合(边线 + 阴影)。
- **src/runtime/components/DataTable.vue**:用 `useScroll`(`arrivedState` + 1px `offset` 容差)与 `useResizeObserver` 派生 `pinStart`/`pinEnd`,挂到 wrapper 的 `data-pin-start`/`data-pin-end`,供主题后代选择器联动。
- **playgrounds/play**:固定列示例叠加 `bordered`、`stripe`,覆盖各行状态。

## 测试

- [x] `pnpm dev:prepare`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`(148 通过)
- [x] `pnpm dev:vue:build`(Vue 模式;编译 CSS 已核对固定列背景与边界阴影规则生成)
- [x] 浏览器肉眼复核 `/data-table/columns` 横向滚动:背景不透明、左右边界阴影按滚动位置显隐

🤖 Generated with [Claude Code](https://claude.com/claude-code)