### PR TITLE
feat(data-table): MDataTable 新增默认展开 defaultExpanded

### DIFF
--- a/docs/app/components/content/examples/data-table/tree/DataTableTreeDefaultExpandExample.vue
+++ b/docs/app/components/content/examples/data-table/tree/DataTableTreeDefaultExpandExample.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { DataTableColumn, DataTableProps } from '@movk/nuxt'
+import type { Person } from '~/composables/useTableMock'
+
+const props = withDefaults(defineProps<{
+  mode?: 'all' | 'depth1' | 'depth2' | 'fn'
+}>(), { mode: 'all' })
+
+const treeData = makePeopleTree(3, 3, 3)
+
+const columns: DataTableColumn<Person>[] = [
+  { type: 'expand' },
+  { accessorKey: 'name', header: '成员' },
+  { accessorKey: 'department', header: '部门' },
+  { accessorKey: 'role', header: '岗位' }
+]
+
+const defaultExpanded = computed<DataTableProps<Person>['defaultExpanded']>(() => {
+  if (props.mode === 'depth1') return 1
+  if (props.mode === 'depth2') return 2
+  if (props.mode === 'fn') return row => row.department === '设计'
+  return true
+})
+</script>
+
+<template>
+  <MDataTable
+    :key="props.mode"
+    :default-expanded="defaultExpanded"
+    :data="treeData"
+    :columns="columns"
+    children-key="children"
+    row-key="id"
+    class="max-h-150"
+  />
+</template>

--- a/docs/app/components/content/examples/data-table/tree/DataTableTreeIndentExample.vue
+++ b/docs/app/components/content/examples/data-table/tree/DataTableTreeIndentExample.vue
@@ -13,5 +13,5 @@ const columns: DataTableColumn<Person>[] = [
 </script>
 
 <template>
-  <MDataTable :data="treeData" :columns="columns" children-key="children" row-key="id" />
+  <MDataTable :default-expanded="1" :data="treeData" :columns="columns" children-key="children" row-key="id" />
 </template>

--- a/docs/content/docs/4.data-table/6.tree.md
+++ b/docs/content/docs/4.data-table/6.tree.md
@@ -66,6 +66,25 @@ options:
 ---
 ::
 
+## `defaultExpanded` 默认展开
+
+`default-expanded` 在未提供 `expanded` / `expanded-keys`（受控优先）时决定初始展开：`true` 展开全部父级行、`number` 展开 `depth` 小于该值的父级行（与 `expandToDepth(n)` 同义）、函数 `(row, depth) => boolean` 按行与深度自定义，无需手写收集父级 id：
+
+::component-example
+---
+name: DataTableTreeDefaultExpandExample
+options:
+  - name: mode
+    label: defaultExpanded
+    items:
+      - all
+      - depth1
+      - depth2
+      - fn
+    default: all
+---
+::
+
 ## 展开行为控制
 
 `expand` 列的 `buttonProps` 与 `toggleAllButtonProps` 分别定制单元格与表头按钮（接收 `isExpanded`/`isAllExpanded`）；`expand-on-row-click` 整行触发展开；expose 的 `expandToDepth(n)` 按层展开、`collapseAll()` 收起全部，`v-model:expanded-keys` 同步展开 id：

--- a/playgrounds/play/app/pages/data-table/tree.vue
+++ b/playgrounds/play/app/pages/data-table/tree.vue
@@ -4,21 +4,6 @@ import type { Person } from '../../composables/useMockData'
 
 const treeData = makePeopleTree(3, 3, 3)
 
-// 收集满足条件的行 id，用于默认展开
-function collectIds(
-  rows: Person[],
-  pred: (row: Person, depth: number) => boolean,
-  depth = 0,
-  acc: string[] = []
-): string[] {
-  for (const row of rows) {
-    if (pred(row, depth)) acc.push(row.id)
-    if (row.children?.length) collectIds(row.children, pred, depth + 1, acc)
-  }
-  return acc
-}
-const allParentIds = collectIds(treeData, row => Boolean(row.children?.length))
-
 // 1. 树形数据基础
 const baseColumns: DataTableColumn<Person>[] = [
   { type: 'expand' },
@@ -85,10 +70,23 @@ const indentColumns: DataTableColumn<Person>[] = [
   { accessorKey: 'department', header: '部门' },
   { accessorKey: 'role', header: '岗位' }
 ]
-// 默认展开全部父节点，使逐层缩进首屏即可见
-const indentExpandedKeys = ref<string[]>([...allParentIds])
 
-// 6. 展开行为控制
+// 6. 默认展开
+const defaultExpandMode = ref<'all' | 'depth1' | 'depth2' | 'fn'>('all')
+const defaultExpanded = computed<DataTableProps<Person>['defaultExpanded']>(() => {
+  if (defaultExpandMode.value === 'depth1') return 1
+  if (defaultExpandMode.value === 'depth2') return 2
+  if (defaultExpandMode.value === 'fn') return row => row.department === '设计'
+  return true
+})
+const defaultExpandColumns: DataTableColumn<Person>[] = [
+  { type: 'expand' },
+  { accessorKey: 'name', header: '成员', size: 200 },
+  { accessorKey: 'department', header: '部门' },
+  { accessorKey: 'role', header: '岗位' }
+]
+
+// 7. 展开行为控制
 const expandRef = useTemplateRef<DataTableExposed<Person>>('expandRef')
 const expandOnRowClick = ref(false)
 const expandedKeys = ref<string[]>([])
@@ -222,13 +220,45 @@ const expandColumns: DataTableColumn<Person>[] = [
       </template>
 
       <MDataTable
-        v-model:expanded-keys="indentExpandedKeys"
+        :default-expanded="1"
         :data="treeData"
         :columns="indentColumns"
         children-key="children"
         row-key="id"
         :indent-size="indentSize"
         bordered
+      />
+    </Showcase>
+
+    <Showcase
+      title="默认展开"
+      description="defaultExpanded 在未受控时决定初始展开：true 展开全部父级行、数字按 depth 展开、函数按行与深度自定义"
+      :state="{ defaultExpandMode }"
+    >
+      <template #toolbar>
+        <USelect
+          v-model="defaultExpandMode"
+          :items="[
+            { label: 'true 全部父级', value: 'all' },
+            { label: '数字 1 一级', value: 'depth1' },
+            { label: '数字 2 两级', value: 'depth2' },
+            { label: '函数 仅设计部门', value: 'fn' }
+          ]"
+          value-key="value"
+          size="xs"
+          class="w-56"
+        />
+      </template>
+
+      <MDataTable
+        :key="defaultExpandMode"
+        :default-expanded="defaultExpanded"
+        :data="treeData"
+        :columns="defaultExpandColumns"
+        children-key="children"
+        row-key="id"
+        bordered
+        class="max-h-150"
       />
     </Showcase>
 

--- a/src/runtime/components/DataTable.vue
+++ b/src/runtime/components/DataTable.vue
@@ -23,6 +23,7 @@ import { useExtendedTv } from '../utils/extend-theme'
 import { resolveColumns } from '../domains/data-table/columns/resolve-columns'
 import { resolveCallbackValue } from '../domains/data-table/columns/utils'
 import { computeTreeRowSelection } from '../domains/data-table/tree-selection'
+import { computeDefaultExpandedKeys } from '../domains/data-table/default-expand'
 import { resolveMaxIndentPx } from '../domains/data-table/indent'
 import { Tree, useInfiniteScrollBinding, separate } from '@movk/core'
 import theme from '#build/movk-ui/data-table'
@@ -124,16 +125,18 @@ function areSameKeys(a: readonly (string | number)[], b: readonly (string | numb
 function useEffectiveModel<V>(
   model: Ref<V | undefined>,
   getDefault: () => V,
-  syncBack?: (value: V) => boolean
+  syncBack?: (value: V) => boolean,
+  // expanded 模型类型含布尔字面量 true，未绑定时 Vue 会将其降级为 false（而非 undefined），需视作未设置
+  isUnset: (value: V | undefined) => boolean = value => value === undefined
 ): WritableComputedRef<V> {
   const effective = computed<V>({
-    get: () => model.value !== undefined ? model.value : getDefault(),
+    get: () => isUnset(model.value) ? getDefault() : model.value as V,
     set: (value) => { model.value = value }
   })
 
   if (syncBack !== undefined) {
     onMounted(() => {
-      if (model.value !== undefined) return
+      if (!isUnset(model.value)) return
       const defaults = getDefault()
       if (syncBack(defaults)) model.value = defaults
     })
@@ -207,12 +210,24 @@ const effectiveRowSelection = useEffectiveModel(
   hasEntries
 )
 
+const defaultExpandedRecord = computed<Record<string, boolean>>(() => {
+  if (!props.childrenKey || !props.defaultExpanded) return {}
+  const data = ((attrs as { data?: T[] }).data ?? []) as T[]
+  return computeDefaultExpandedKeys(data, {
+    defaultExpanded: props.defaultExpanded,
+    childrenKey: props.childrenKey,
+    rowKey: props.rowKey
+  })
+})
+
 const effectiveExpanded = useEffectiveModel(
   expandedState,
   () => expandedKeysState.value !== undefined
     ? keysToExpanded(expandedKeysState.value)
-    : {},
-  hasEntries
+    : defaultExpandedRecord.value,
+  hasEntries,
+  // 运行时 Vue 把未绑定的布尔型 expanded 模型降级为 false，类型层不体现，故断言比较
+  value => value === undefined || (value as unknown) === false
 )
 
 useSyncKeys(

--- a/src/runtime/domains/data-table/default-expand.ts
+++ b/src/runtime/domains/data-table/default-expand.ts
@@ -1,0 +1,45 @@
+import type { DataTableProps } from '../../types/data-table'
+
+interface DefaultExpandOptions<T> {
+  defaultExpanded: DataTableProps<T>['defaultExpanded']
+  childrenKey?: string
+  rowKey?: string
+}
+
+/**
+ * 由 `defaultExpanded` 推导初始展开记录（id → true），用于树形模式默认展开
+ *
+ * 仅命中「有非空 children 数组」的父级行（对齐 TanStack `getCanExpand`）；
+ * id 派生复刻 TanStack 默认 `getRowId`：有 `rowKey` 取 `String(row[rowKey])`，
+ * 否则根层为 `index`、子层为 `parentId.index`。
+ */
+export function computeDefaultExpandedKeys<T>(
+  data: readonly T[],
+  options: DefaultExpandOptions<T>
+): Record<string, boolean> {
+  const { defaultExpanded, childrenKey, rowKey } = options
+  if (!defaultExpanded || !childrenKey) return {}
+
+  const predicate = typeof defaultExpanded === 'function'
+    ? defaultExpanded
+    : typeof defaultExpanded === 'number'
+      ? (_row: T, depth: number) => depth < defaultExpanded
+      : () => true
+
+  const result: Record<string, boolean> = {}
+
+  const walk = (rows: readonly T[], depth: number, parentId?: string): void => {
+    rows.forEach((row, index) => {
+      const children = (row as Record<string, unknown>)[childrenKey]
+      if (!Array.isArray(children) || children.length === 0) return
+      const id = rowKey !== undefined
+        ? String((row as Record<string, unknown>)[rowKey])
+        : parentId !== undefined ? `${parentId}.${index}` : `${index}`
+      if (predicate(row, depth)) result[id] = true
+      walk(children as T[], depth + 1, id)
+    })
+  }
+
+  walk(data, 0)
+  return result
+}

--- a/src/runtime/types/data-table/component.ts
+++ b/src/runtime/types/data-table/component.ts
@@ -154,6 +154,11 @@ export interface DataTableProps<T extends TableData> extends /* @vue-ignore */ O
    * @defaultValue '1rem'
    */
   indentSize?: number | string | ((ctx: CellContext<T, unknown>) => string)
+  /**
+   * 树形模式下的默认展开行为，仅在未提供 expanded / expandedKeys 时生效。true 展开全部父级行，number 展开 depth 小于该值的父级行，函数按行与深度自定义
+   * @defaultValue false
+   */
+  defaultExpanded?: boolean | number | ((row: T, depth: number) => boolean)
   expandedOptions?: TableProps<T>['expandedOptions']
   /** @defaultValue false */
   expandOnRowClick?: boolean

--- a/test/domains/data-table/default-expand.test.ts
+++ b/test/domains/data-table/default-expand.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeDefaultExpandedKeys } from '../../../src/runtime/domains/data-table/default-expand'
+
+interface Node {
+  id?: string
+  name?: string
+  children?: Node[]
+}
+
+// a:0 ─ a1:1 ─ a1x:2(leaf)
+//      └ a2:1(leaf)
+// b:0(空 children，不可展开)
+// c:0(leaf)
+const tree: Node[] = [
+  {
+    id: 'a',
+    children: [
+      { id: 'a1', children: [{ id: 'a1x' }] },
+      { id: 'a2' }
+    ]
+  },
+  { id: 'b', children: [] },
+  { id: 'c' }
+]
+
+describe('computeDefaultExpandedKeys', () => {
+  it('空数据返回 {}', () => {
+    expect(computeDefaultExpandedKeys([], { defaultExpanded: true, childrenKey: 'children', rowKey: 'id' })).toEqual({})
+  })
+
+  it('未提供 childrenKey 返回 {}', () => {
+    expect(computeDefaultExpandedKeys(tree, { defaultExpanded: true, rowKey: 'id' })).toEqual({})
+  })
+
+  it('defaultExpanded 为 false 返回 {}', () => {
+    expect(computeDefaultExpandedKeys(tree, { defaultExpanded: false, childrenKey: 'children', rowKey: 'id' })).toEqual({})
+  })
+
+  it('true 展开全部父级行，排除叶子与空 children', () => {
+    expect(computeDefaultExpandedKeys(tree, { defaultExpanded: true, childrenKey: 'children', rowKey: 'id' }))
+      .toEqual({ a: true, a1: true })
+  })
+
+  it('number 1 仅展开 depth < 1 的父级行', () => {
+    expect(computeDefaultExpandedKeys(tree, { defaultExpanded: 1, childrenKey: 'children', rowKey: 'id' }))
+      .toEqual({ a: true })
+  })
+
+  it('number 2 展开 depth < 2 的父级行', () => {
+    expect(computeDefaultExpandedKeys(tree, { defaultExpanded: 2, childrenKey: 'children', rowKey: 'id' }))
+      .toEqual({ a: true, a1: true })
+  })
+
+  it('函数谓词按行与深度判定', () => {
+    expect(computeDefaultExpandedKeys(tree, {
+      defaultExpanded: (_row, depth) => depth === 0,
+      childrenKey: 'children',
+      rowKey: 'id'
+    })).toEqual({ a: true })
+
+    expect(computeDefaultExpandedKeys(tree, {
+      defaultExpanded: row => row.id === 'a1',
+      childrenKey: 'children',
+      rowKey: 'id'
+    })).toEqual({ a1: true })
+  })
+
+  it('无 rowKey 时按 TanStack 默认 id 路径派生', () => {
+    // 根节点 index 0 → '0'；其第 1 个子节点(含 children) → '0.1'
+    const indexed: Node[] = [
+      {
+        children: [
+          { name: 'leaf' },
+          { children: [{ name: 'deep-leaf' }] }
+        ]
+      }
+    ]
+    expect(computeDefaultExpandedKeys(indexed, { defaultExpanded: true, childrenKey: 'children' }))
+      .toEqual({ 0: true, 0.1: true })
+  })
+})


### PR DESCRIPTION
## 概述

为 MDataTable 树形模式新增声明式默认展开能力 `defaultExpanded`，并修复 expanded 模型未设置态被 Vue 降级为 `false` 导致默认展开失效的问题。

## 改动

- 新增 prop `defaultExpanded?: boolean | number | ((row, depth) => boolean)`
  - `true` 展开全部父级行
  - `number` 展开 depth 小于该值的父级行（与 `expandToDepth(n)` 同义）
  - 函数按行与深度自定义
  - 受控优先：显式 `expanded` / `expandedKeys` 高于 `defaultExpanded`
- 新增 domain 纯函数 `computeDefaultExpandedKeys`（复刻 TanStack 默认 getRowId 派生 id，无 rowKey 时走索引路径）
- 修复 `useEffectiveModel`：新增 `isUnset` 判定，expanded 模型将 `false` 视作未设置，使默认值正常落回 `getDefault`
- playground `tree.vue` 清理手写 `collectIds` 样板，新增「默认展开」Showcase
- docs 新增「defaultExpanded 默认展开」章节与示例组件

## 测试计划

- [x] `pnpm test`（新增 default-expand 用例，156 passed）
- [x] `pnpm lint`
- [x] `pnpm typecheck`（src + play + docs + vue）
- [x] `pnpm dev:vue:build`（纯 Vue 模式）
- [x] SSR 实测 `/data-table/tree`：默认展开行数 0 → 78，确认生效

> 注：本分支基于 `fix/data-table-pinned-bg-shadow`，包含其固定列背景/阴影修复提交，待该分支合并后此 PR diff 将仅含本特性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)