### PR TITLE
feat(search-form): reset/clear 事件携带可清空字段载荷

### DIFF
--- a/src/runtime/components/SearchForm.vue
+++ b/src/runtime/components/SearchForm.vue
@@ -38,7 +38,7 @@ const props = withDefaults(defineProps<SearchFormProps<S> & {
 
 const modelValue = defineModel<Partial<InferInput<S>>>({ default: () => ({}) })
 const expandedModel = defineModel<boolean>('expanded')
-const emits = defineEmits<SearchFormEmits>()
+const emits = defineEmits<SearchFormEmits<S>>()
 const slots = defineSlots<SearchFormSlots<S>>()
 defineOptions({ inheritAttrs: false })
 
@@ -161,17 +161,27 @@ function submit() {
   formRef.value?.submit()
 }
 
+// 覆盖全部 schema 字段的载荷：清空字段为 undefined，有默认值的字段为其默认值，
+// 供合并语义的消费方（handleSearch）据此覆盖每个搜索字段
+function buildFieldPayload(): Partial<InferInput<S>> {
+  const keys = Object.keys(props.schema.shape) as (keyof InferInput<S>)[]
+  return keys.reduce((acc, key) => {
+    acc[key] = modelValue.value[key]
+    return acc
+  }, {} as Partial<InferInput<S>>)
+}
+
 function clear() {
   modelValue.value = {} as Partial<InferInput<S>>
   formRef.value?.clear()
-  emits('clear')
+  emits('clear', buildFieldPayload())
 }
 
 function reset() {
   modelValue.value = deepClone(baseline)
   applyFieldDefaults(fields.value, modelValue.value)
   formRef.value?.clear()
-  emits('reset')
+  emits('reset', buildFieldPayload())
 }
 
 function setBaseline(value?: Partial<InferInput<S>>) {

--- a/src/runtime/types/auto-form/search-form.ts
+++ b/src/runtime/types/auto-form/search-form.ts
@@ -79,9 +79,9 @@ export interface SearchFormProps<S extends z.ZodObject> extends BaseAutoFormProp
   defaultExpanded?: boolean
 }
 
-export interface SearchFormEmits {
-  'reset': []
-  'clear': []
+export interface SearchFormEmits<S extends z.ZodObject = z.ZodObject> {
+  'reset': [state: Partial<InferInput<S>>]
+  'clear': [state: Partial<InferInput<S>>]
   'expand': [expanded: boolean]
   'update:expanded': [expanded: boolean]
   'error': [event: FormErrorEvent]


### PR DESCRIPTION
## 背景

`MSearchForm` 的 `@reset` / `@clear` 事件此前**不携带任何参数**。而消费方列表页的 `handleSearch` 均为**合并语义**：

```ts
query.value = { ...query.value, ...params, page: 0 }
```

合并意味着传 `{}` / `undefined` 无法删除已应用的旧条件，消费方只能手工枚举每个字段为 `undefined` 才能重置（冗长且易漏字段），或直接失效（如 `handleSearch({})`）。

## 改动

- `SearchForm.vue` 新增 `buildFieldPayload()`：在 `modelValue` 重置/清空后，按 `props.schema.shape` 的键构造覆盖全部字段的载荷（清空字段为 `undefined`，有默认值的字段为其默认值）。
- `reset()` / `clear()` 改为 `emits('reset', buildFieldPayload())` / `emits('clear', ...)`。
- `SearchFormEmits` 泛型化为 `SearchFormEmits<S>`，`reset` / `clear` 增加 `[state: Partial<InferInput<S>>]` 载荷；组件 `defineEmits<SearchFormEmits<S>>()`。

消费方此后只需 `@reset="onSearchReset"` 且 `onSearchReset(state) => handleSearch(state)`，无需枚举字段；非 schema 字段（分页、外部管理的 `deptId` 等）天然不被清空。

## 兼容性

向后兼容：现有忽略事件参数的 `@reset` 写法不受影响（多出的 emit 参数被忽略）。

## 验证

- `pnpm lint` 通过
- `vue-tsc --noEmit` 通过
- `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)