### PR TITLE
fix(search-form): 重置/清空载荷基于待写入 state 构造

### DIFF
--- a/src/runtime/components/SearchForm.vue
+++ b/src/runtime/components/SearchForm.vue
@@ -162,26 +162,30 @@ function submit() {
 }
 
 // 覆盖全部 schema 字段的载荷：清空字段为 undefined，有默认值的字段为其默认值，
-// 供合并语义的消费方（handleSearch）据此覆盖每个搜索字段
-function buildFieldPayload(): Partial<InferInput<S>> {
+// 供合并语义的消费方（handleSearch）据此覆盖每个搜索字段。
+// 基于即将写入的 state 构造，而非回读 modelValue——defineModel 写入不会同步回流，
+// 回读会拿到旧值导致已填字段无法清空
+function buildFieldPayload(state: Partial<InferInput<S>>): Partial<InferInput<S>> {
   const keys = Object.keys(props.schema.shape) as (keyof InferInput<S>)[]
   return keys.reduce((acc, key) => {
-    acc[key] = modelValue.value[key]
+    acc[key] = state[key]
     return acc
   }, {} as Partial<InferInput<S>>)
 }
 
 function clear() {
-  modelValue.value = {} as Partial<InferInput<S>>
+  const next = {} as Partial<InferInput<S>>
+  modelValue.value = next
   formRef.value?.clear()
-  emits('clear', buildFieldPayload())
+  emits('clear', buildFieldPayload(next))
 }
 
 function reset() {
-  modelValue.value = deepClone(baseline)
-  applyFieldDefaults(fields.value, modelValue.value)
+  const next = deepClone(baseline)
+  applyFieldDefaults(fields.value, next)
+  modelValue.value = next
   formRef.value?.clear()
-  emits('reset', buildFieldPayload())
+  emits('reset', buildFieldPayload(next))
 }
 
 function setBaseline(value?: Partial<InferInput<S>>) {


### PR DESCRIPTION
## 背景

接 #135：`@reset` / `@clear` 现会 emit 覆盖全部 schema 字段的载荷。但实测重置时已填字段（如 `nickname`）无法清空——`buildFieldPayload` 在写入 `modelValue` 后**回读**它构造载荷，而 `MSearchForm` 的 `modelValue` 是 `defineModel`，写入是「改本地 + emit 给父级」，父 prop 不会在同一 tick 同步回流，回读拿到的是旧值。

## 改动

`buildFieldPayload(state)` 改为基于**即将写入的 `next` 对象**构造载荷，而非回读 `modelValue`：先 `deepClone(baseline)` 得到 `next`、对 `next` 应用默认值，再赋给 `modelValue` 并用 `next` 构造载荷。`clear()` 同理。

## 验证

- `pnpm lint` 通过
- `vue-tsc --noEmit` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)