### PR TITLE
fix(tree): 修复异步数据下 defaultExpanded 失效

### DIFF
--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -66,7 +66,7 @@ const baseItems = ref<WorkNode[]>([])
 let initialized = false
 watch(() => props.items, (items) => {
   baseItems.value = buildBase((items ?? []) as WorkNode[])
-  if (!initialized) {
+  if (!initialized && baseItems.value.length > 0) {
     initialized = true
     if (expanded.value.length === 0) {
       // 按类型走策略分支，确保 number 0（收起全部）不被当作假值；


### PR DESCRIPTION
## 背景

`MTree` 配置 `default-expanded` 但异步加载的数据未展开（根节点处于收起态）。

## 根因

[Tree.vue](src/runtime/components/Tree.vue) 的初始化 `watch` 带 `immediate: true`，组件挂载时立即以**空** `items` 触发一次：`initialized` 被置为 `true`、`resolveDefaultExpandedKeys([], ...)` 返回空数组。随后真实数据异步到达再次触发 watch 时，`if (!initialized)` 守卫已为 `false`，默认展开计算被永久跳过。

同步传入静态 `items` 不受影响（首次 immediate 即带数据），故此前未暴露。对照 `DataTable` 用 `computed` 实现默认展开，对异步数据天然响应，无此问题。

## 改动

守卫从「首次 watch 触发」改为「首次拿到非空数据」（`!initialized && baseItems.value.length > 0`），分支计算逻辑与 `expanded.length === 0` 内层守卫均保留。顺带修复节点级 `defaultExpanded` 标记在异步数据下同样失效的问题。

## 测试

- [x] `pnpm test`：195 用例全过
- [x] `vue-tsc --noEmit`：无类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)