### PR TITLE
fix(tree): 根容器正确继承用户透传 class

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -52,7 +52,8 @@ export default defineAppConfig({
           'SearchForm 如何按行数自动折叠？',
           'PillGroup 如何做多选与字段映射？',
           'DatePicker 输出格式与预设如何配置？',
-          'With* 输入增强（清除/复制/字数/密码）怎么用？'
+          'With* 输入增强（清除/复制/字数/密码）怎么用？',
+          'Tree 复选框级联、父子策略与异步懒加载如何配置？'
         ]
       },
       {

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -314,7 +314,7 @@ defineExpose<TreeExposed<T>>({
 </script>
 
 <template>
-  <div :class="extraUi.container">
+  <div :class="extraUi.container" data-slot="container">
     <slot
       v-if="props.toolbar || props.searchable || slots.toolbar"
       name="toolbar"
@@ -353,7 +353,7 @@ defineExpose<TreeExposed<T>>({
       </TreeToolbar>
     </slot>
 
-    <div v-if="isEmpty" :class="extraUi.empty">
+    <div v-if="isEmpty" :class="extraUi.empty" data-slot="empty">
       <slot name="empty">
         无匹配结果
       </slot>

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -365,7 +365,7 @@ defineExpose<TreeExposed<T>>({
       :items="(displayItems as any)"
       :model-value="(effectiveModel as any)"
       :expanded="expanded"
-      :ui="(baseUi as any)"
+      :ui="baseUi"
       @update:model-value="onModelUpdate($event as ModelValue)"
       @update:expanded="onExpandedUpdate"
     >

--- a/src/runtime/domains/tree/components/TreeToolbar.vue
+++ b/src/runtime/domains/tree/components/TreeToolbar.vue
@@ -40,7 +40,7 @@ function onToggleAll(checked: boolean) {
 </script>
 
 <template>
-  <div :class="ui.toolbar">
+  <div :class="ui.toolbar" data-slot="toolbar">
     <slot name="leading" />
 
     <UInput

--- a/src/runtime/types/components/tree.ts
+++ b/src/runtime/types/components/tree.ts
@@ -96,6 +96,7 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
   /** 渲染复选框并启用多选（multiple + strategy，默认 cascade） */
   checkable?: M & boolean
   ui?: Record<string, ClassNameValue>
+  class?: ClassNameValue
 }
 
 /** 父子勾选策略 */


### PR DESCRIPTION
## 背景

`<MTree class="...">` 传入的 class 没有应用到根容器 `<div :class="extraUi.container">`。

## 根因

`TreeProps`（src/runtime/types/components/tree.ts）通过 `extends /** @vue-ignore */ OmitByKey<NuxtTreeProps<...>>` 继承官方 props，`@vue-ignore` 使 Vue 编译器丢弃被继承成员作为运行时 prop。`class` 既未在 interface body 内显式声明，也只能来自被吞基类，故运行时 `props.class === undefined`：

- `container: [props.ui?.container, props.class]` 只剩 `props.ui?.container`，容器不继承 class；
- 因 `inheritAttrs: false`，未声明的 `class` 落入 `$attrs`，又被 `v-bind` 到内部 `UTree`，错绑到内部元素。

同类薄壳组件（StarRating / PillGroup / DataTable / SearchForm / AutoForm / SlideVerify）均已显式声明 `class?: ClassNameValue`，唯独 Tree 漏了。

## 改动

- `src/runtime/types/components/tree.ts`：`TreeProps` 补 `class?: ClassNameValue`，与同类组件对齐。声明为真实 prop 后，`props.class` 正确取值并合入 `extraUi.container`，同时从 `$attrs` 移除避免错绑到 UTree。
- `src/runtime/components/Tree.vue`：移除 `:ui` 上多余的 `as any` 断言。
- `docs/app/app.config.ts`：补充 Tree 相关示例提示文案。

## 测试计划

- [x] `pnpm typecheck` 通过
- [ ] `pnpm dev`：`<MTree class="border rounded-md p-2">` 渲染到根 div.container 而非内部 UTree
- [ ] `pnpm dev:vue:build`：Vue 模式同样生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)