### PR TITLE
docs(auto-form): 补充异步 items 须用函数式 controlProps 的提示

### DIFF
--- a/docs/content/docs/3.auto-form/14.reactive.md
+++ b/docs/content/docs/3.auto-form/14.reactive.md
@@ -50,6 +50,12 @@ collapse: true
 ---
 ::
 
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+当 `items` 来源是**异步或外部响应式数据**（基于 `useApiFetch`、`useAsyncData` 的 `computed` / `ref`）时，务必用**函数式** `controlProps: () => ({ items: source.value })`，或直接传响应式来源 `items: source`，切勿写成 `items: source.value`。
+
+schema 在 `setup` 期只构建一次，`source.value` 是当时的一次性快照：SSR 注水时数据恰好就绪会「看似正常」，但客户端导航重新挂载、异步数据尚未到达时会冻结为空数组，后续选项更新不再生效。函数式 `controlProps` 在渲染时实时求值，可规避此问题。
+::
+
 ## API
 
 ### `meta`


### PR DESCRIPTION
异步或外部响应式来源的 items 若以 source.value 快照写入 controlProps， schema 在 setup 期只构建一次，客户端导航重新挂载、数据未就绪时会冻结为空数组。 新增 callout 说明应使用函数式 controlProps 或直接传响应式来源。