### PR TITLE
fix(api): useApiFetch 缓存键深解包 query 与 body 内嵌套 ref

### DIFF
--- a/src/runtime/composables/useApiFetch.ts
+++ b/src/runtime/composables/useApiFetch.ts
@@ -3,6 +3,7 @@ import type { UseApiFetchOptions, UseApiFetchReturn } from '../types/api'
 import { computed, toValue } from 'vue'
 import { useNuxtApp, useFetch } from '#app'
 import { buildApiFetchKey } from '../domains/api/fetch-key'
+import { deepToValue } from '../domains/api/deep-to-value'
 
 /**
  * API Fetch 组合式函数
@@ -77,8 +78,8 @@ export function useApiFetch<T = unknown, DataT = T>(
       toast,
       method: toValue(fetchOptions.method),
       url: typeof url === 'function' ? url() : url,
-      query: toValue(fetchOptions.query),
-      body: toValue(fetchOptions.body)
+      query: deepToValue(fetchOptions.query),
+      body: deepToValue(fetchOptions.body)
     })
   })
 

--- a/src/runtime/domains/api/deep-to-value.ts
+++ b/src/runtime/domains/api/deep-to-value.ts
@@ -1,0 +1,21 @@
+import { toValue } from 'vue'
+
+/**
+ * 递归解包嵌套 ref，产出纯值结构
+ *
+ * @description Vue 的 toValue 仅解包顶层 ref，不会解包普通对象 / 数组内部的嵌套 ref。
+ * useApiFetch 的 query / body 常写成 `{ key: ref }`（Nuxt useFetch 允许字段为 ref），
+ * 若仅浅解包，buildApiFetchKey 序列化时会把 Ref 对象本身计入，导致不同值派生出相同 key 而缓存碰撞。
+ * 仅对纯对象 / 数组递归；Date / File / FormData 等非纯对象原样返回，避免破坏与栈溢出。
+ */
+export function deepToValue(value: unknown): unknown {
+  const resolved = toValue(value)
+  if (Array.isArray(resolved)) return resolved.map(deepToValue)
+  if (resolved !== null && typeof resolved === 'object'
+    && Object.getPrototypeOf(resolved) === Object.prototype) {
+    return Object.fromEntries(
+      Object.entries(resolved).map(([k, v]) => [k, deepToValue(v)])
+    )
+  }
+  return resolved
+}

--- a/test/domains/api/deep-to-value.test.ts
+++ b/test/domains/api/deep-to-value.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { computed, reactive, ref } from 'vue'
+import { deepToValue } from '../../../src/runtime/domains/api/deep-to-value'
+
+describe('domains/api/deep-to-value.deepToValue', () => {
+  it('解包顶层 ref', () => {
+    expect(deepToValue(ref('USER_SEX'))).toBe('USER_SEX')
+  })
+
+  it('解包对象内的嵌套 ref', () => {
+    const dictType = ref('USER_SEX')
+    expect(deepToValue({ dictType })).toEqual({ dictType: 'USER_SEX' })
+  })
+
+  it('解包数组内的嵌套 ref', () => {
+    expect(deepToValue([ref(1), ref(2)])).toEqual([1, 2])
+  })
+
+  it('解包深层嵌套（对象套数组套 ref）', () => {
+    const input = { filters: [{ id: ref('a') }], page: ref(0) }
+    expect(deepToValue(input)).toEqual({ filters: [{ id: 'a' }], page: 0 })
+  })
+
+  it('解包 reactive 对象内的字段', () => {
+    const state = reactive({ dictType: 'USER_STATUS' })
+    expect(deepToValue(state)).toEqual({ dictType: 'USER_STATUS' })
+  })
+
+  it('不同 ref 值解包后不相等（避免 key 碰撞的根因）', () => {
+    const a = deepToValue({ dictType: ref('USER_SEX') })
+    const b = deepToValue({ dictType: ref('USER_STATUS') })
+    expect(a).not.toEqual(b)
+  })
+
+  it('computed 值变化后解包反映新值', () => {
+    const base = ref('a')
+    const c = computed(() => base.value)
+    const query = { dictType: c }
+    expect(deepToValue(query)).toEqual({ dictType: 'a' })
+    base.value = 'b'
+    expect(deepToValue(query)).toEqual({ dictType: 'b' })
+  })
+
+  it('非纯对象（Date）原样返回', () => {
+    const d = new Date('2026-06-25T00:00:00.000Z')
+    expect(deepToValue(d)).toBe(d)
+  })
+
+  it('原始值原样返回', () => {
+    expect(deepToValue(0)).toBe(0)
+    expect(deepToValue(null)).toBe(null)
+    expect(deepToValue(undefined)).toBe(undefined)
+    expect(deepToValue('x')).toBe('x')
+  })
+})


### PR DESCRIPTION
## 背景

`useApiFetch` 自定义缓存 key（经 `buildApiFetchKey`）以纳入 `toast` / `skipBusinessCheck` 等请求级维度去重。但 key 派生时对 `query` / `body` 仅用 `toValue` **浅解包**——当 query 写成 `{ key: ref }`（Nuxt `useFetch` 允许字段为 ref，如 `useDict` 的 `{ dictType: computed }`）时，内部 ref 未被解包就计入 payload，`JSON.stringify` 后 Ref 对象与具体值无关，导致**不同参数派生出相同 key**，被 `useAsyncData` 去重复用首个 handler。

表现：同页两个 `useDict('sys_user_sex')` 与 `useDict('sys_user_status')` 互相串数据。

实际网络请求不受影响（底层 `useFetch` 收到原始响应式 query 会自行解包），缺陷仅限 key 派生。

## 改动

- 新增 `deepToValue`（`src/runtime/domains/api/deep-to-value.ts`）：递归解包纯对象/数组内的嵌套 ref；`Date`/`File`/`FormData` 等非纯对象原样返回，避免破坏与栈溢出。
- `useApiFetch` 的 key 派生改用 `deepToValue(query)` / `deepToValue(body)`。
- `buildApiFetchKey` 契约（入参须为已 resolve 的值）不变，责任仍在调用方完整 resolve。

## 测试

- 新增 `test/domains/api/deep-to-value.test.ts`（9 例）：覆盖顶层/对象/数组/深层嵌套/reactive/computed 变更/不同值不碰撞/非纯对象与原始值原样。
- `pnpm vitest run test/domains/api test/composables` → 137 passed。
- `pnpm lint`、`vue-tsc --noEmit` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)