### PR TITLE
fix(api): useApiFetch 用户钩子与内置拦截器组合而非覆盖

### DIFF
--- a/docs/content/docs/5.api/4.use-api-fetch.md
+++ b/docs/content/docs/5.api/4.use-api-fetch.md
@@ -310,12 +310,12 @@ await useApiFetch('/users', {
         ::
 
         ::field{name="onResponse" type="(context: FetchContext & { response: Response }) => Promise<void> | void"}
-  收到响应时的钩子。与内置钩子合并执行。
+  收到响应时的钩子。内置钩子先执行，因此 `response._data` 已是解包后的业务数据（除非 `skipUnwrap: true`），且仅业务成功时触发。返回值被 ofetch 忽略，仅用于副作用；变形输出请用 `transform`。
 
           ::collapsible
           ```ts
           onResponse({ response }) {
-            console.log('收到响应:', response.status)
+            console.log('已解包数据:', response._data)
           }
           ```
           ::

--- a/src/runtime/composables/useApiFetch.ts
+++ b/src/runtime/composables/useApiFetch.ts
@@ -4,6 +4,7 @@ import { computed, toValue } from 'vue'
 import { useNuxtApp, useFetch } from '#app'
 import { buildApiFetchKey } from '../domains/api/fetch-key'
 import { deepToValue } from '../domains/api/deep-to-value'
+import { composeHook, getInterceptors } from '../domains/api/interceptors/compose'
 
 /**
  * API Fetch 组合式函数
@@ -43,13 +44,16 @@ import { deepToValue } from '../domains/api/deep-to-value'
  * // 跳过解包，拿原始响应（与 skipBusinessCheck 正交）
  * const { data } = await useApiFetch<ApiResponse>('/external', { skipUnwrap: true })
  *
- * // 用户自定义 hooks（通过 useFetch 原生选项透传）
+ * // 用户自定义 hooks：与内置拦截器组合（内置先执行），不会覆盖认证/业务校验/解包/Toast
  * const { data } = await useApiFetch('/users', {
  *   onResponse({ response }) {
  *     // response._data 已是解包后的业务数据（除非传入 skipUnwrap: true）
+ *     // 仅业务成功时触发；返回值被 ofetch 忽略，副作用专用
  *     console.log('自定义处理:', response._data)
  *   }
  * })
+ *
+ * // 变形输出请用 transform 或直接消费自动解包后的 data，而非在 onResponse 中 return
  * ```
  */
 export function useApiFetch<T = unknown, DataT = T>(
@@ -68,6 +72,19 @@ export function useApiFetch<T = unknown, DataT = T>(
 
   const apiInstance = endpoint ? $api.use(endpoint) : $api
 
+  // 用户钩子与内置拦截器组合为数组（内置先执行）；仅覆写用户实际传入的钩子，避免顶掉实例 default
+  const movk = getInterceptors(apiInstance)
+  const composedHooks = movk
+    ? {
+        onRequest: composeHook(movk.onRequest, fetchOptions.onRequest),
+        onResponse: composeHook(movk.onResponse, fetchOptions.onResponse),
+        onResponseError: composeHook(movk.onResponseError, fetchOptions.onResponseError)
+      }
+    : {}
+  const definedHooks = Object.fromEntries(
+    Object.entries(composedHooks).filter(([, value]) => value !== undefined)
+  )
+
   const fetchKey = computed<string>(() => {
     const userKey = toValue(fetchOptions.key)
     if (userKey) return userKey
@@ -85,6 +102,7 @@ export function useApiFetch<T = unknown, DataT = T>(
 
   return useFetch(url, {
     ...fetchOptions,
+    ...definedHooks,
     key: fetchKey,
     $fetch: apiInstance as typeof $fetch,
     context: { toast, skipBusinessCheck, skipUnwrap }

--- a/src/runtime/domains/api/interceptors/compose.ts
+++ b/src/runtime/domains/api/interceptors/compose.ts
@@ -1,0 +1,49 @@
+import type { $Fetch } from 'nitropack/types'
+import type { FetchHook } from 'ofetch'
+
+/**
+ * 单端点的 movk 内置拦截器集合
+ * @description 由 api.factory 在创建 $fetch 实例时挂到实例上，供 useApiFetch 在用户传入同名钩子时组合复用
+ */
+export interface MovkInterceptors {
+  onRequest: FetchHook
+  onResponse: FetchHook
+  onResponseError: FetchHook
+}
+
+const MOVK_INTERCEPTORS = Symbol('movk:interceptors')
+
+interface WithInterceptors {
+  [MOVK_INTERCEPTORS]?: MovkInterceptors
+}
+
+/**
+ * 把 movk 内置拦截器以非枚举符号挂到 $fetch 实例
+ * @description 符号键不进入 ApiInstance 公共类型，强转集中于此
+ */
+export function attachInterceptors(instance: $Fetch, interceptors: MovkInterceptors): void {
+  Object.defineProperty(instance, MOVK_INTERCEPTORS, {
+    value: interceptors,
+    enumerable: false,
+    configurable: true
+  })
+}
+
+/** 读取实例上挂载的 movk 内置拦截器 */
+export function getInterceptors(instance: $Fetch): MovkInterceptors | undefined {
+  return (instance as WithInterceptors)[MOVK_INTERCEPTORS]
+}
+
+function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * 组合 movk 内置钩子与用户钩子为数组（movk 先执行）
+ * @description 用户未传钩子时返回 undefined，让 ofetch 沿用实例 default（不覆盖）；
+ * 用户传入时返回 `[movkHook, ...userHooks]`，使用户钩子拿到 movk 处理后的上下文
+ */
+export function composeHook<H>(movkHook: H, userHook: H | H[] | undefined): H[] | undefined {
+  if (userHook === undefined) return undefined
+  return [movkHook, ...toArray(userHook)]
+}

--- a/src/runtime/plugins/api.factory.ts
+++ b/src/runtime/plugins/api.factory.ts
@@ -5,6 +5,7 @@ import { resolveEndpointConfig } from '../domains/api/endpoint-config'
 import { createOnRequest } from '../domains/api/interceptors/request'
 import { createOnResponse } from '../domains/api/interceptors/response'
 import { createOnResponseError } from '../domains/api/interceptors/error'
+import { attachInterceptors } from '../domains/api/interceptors/compose'
 import { defineNuxtPlugin, useNuxtApp, useRuntimeConfig } from '#imports'
 
 type NuxtApp = ReturnType<typeof useNuxtApp>
@@ -19,13 +20,22 @@ function createEndpointFetch(
   publicConfig: MovkApiPublicConfig,
   nuxtApp: NuxtApp
 ): $Fetch {
-  return $fetch.create({
-    baseURL: resolvedConfig.baseURL,
-    headers: resolvedConfig.headers,
+  const interceptors = {
     onRequest: createOnRequest(resolvedConfig, publicConfig, nuxtApp),
     onResponse: createOnResponse(resolvedConfig, publicConfig, nuxtApp),
     onResponseError: createOnResponseError(resolvedConfig, publicConfig, nuxtApp)
+  }
+
+  const instance = $fetch.create({
+    baseURL: resolvedConfig.baseURL,
+    headers: resolvedConfig.headers,
+    ...interceptors
   })
+
+  // 挂到实例供 useApiFetch 组合复用：用户传同名钩子时不致覆盖内置拦截器
+  attachInterceptors(instance, interceptors)
+
+  return instance
 }
 
 export default defineNuxtPlugin(() => {

--- a/test/composables/useApiFetch.test.ts
+++ b/test/composables/useApiFetch.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FetchHook } from 'ofetch'
+import { attachInterceptors } from '../../src/runtime/domains/api/interceptors/compose'
+
+const useFetchMock = vi.fn(() => ({}))
+
+function makeMovk() {
+  return {
+    onRequest: (() => {}) as FetchHook,
+    onResponse: (() => {}) as FetchHook,
+    onResponseError: (() => {}) as FetchHook
+  }
+}
+
+const defaultMovk = makeMovk()
+const v2Movk = makeMovk()
+
+function makeInstance(interceptors: ReturnType<typeof makeMovk>) {
+  const instance = Object.assign(() => {}, {
+    use: (endpoint: string) => (endpoint === 'v2' ? v2Instance : instance)
+  })
+  attachInterceptors(instance as never, interceptors)
+  return instance
+}
+
+const v2Instance = makeInstance(v2Movk)
+const defaultInstance = makeInstance(defaultMovk)
+
+vi.mock('#app', () => ({
+  useNuxtApp: () => ({ $api: defaultInstance }),
+  useFetch: useFetchMock
+}))
+
+const { useApiFetch } = await import('../../src/runtime/composables/useApiFetch')
+
+function lastOptions() {
+  return useFetchMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+}
+
+describe('useApiFetch 钩子组合', () => {
+  beforeEach(() => {
+    useFetchMock.mockClear()
+  })
+
+  it('用户传 onResponse 时组合为 [movk, user]，movk 在前', () => {
+    const userOnResponse: FetchHook = () => {}
+    useApiFetch('/users', { onResponse: userOnResponse })
+
+    const onResponse = lastOptions().onResponse as FetchHook[]
+    expect(onResponse).toEqual([defaultMovk.onResponse, userOnResponse])
+    expect(onResponse[0]).toBe(defaultMovk.onResponse)
+  })
+
+  it('用户未传钩子时 options 不含 onResponse 键（保持实例 default）', () => {
+    useApiFetch('/users')
+
+    expect('onResponse' in lastOptions()).toBe(false)
+    expect('onRequest' in lastOptions()).toBe(false)
+    expect('onResponseError' in lastOptions()).toBe(false)
+  })
+
+  it('指定 endpoint 时组合该端点实例的拦截器', () => {
+    const userOnResponse: FetchHook = () => {}
+    useApiFetch('/users', { endpoint: 'v2', onResponse: userOnResponse })
+
+    const onResponse = lastOptions().onResponse as FetchHook[]
+    expect(onResponse[0]).toBe(v2Movk.onResponse)
+    expect(onResponse[0]).not.toBe(defaultMovk.onResponse)
+  })
+
+  it('用户数组钩子与 onRequest 一并组合', () => {
+    const a: FetchHook = () => {}
+    const b: FetchHook = () => {}
+    useApiFetch('/users', { onRequest: [a, b] })
+
+    expect(lastOptions().onRequest).toEqual([defaultMovk.onRequest, a, b])
+  })
+})

--- a/test/domains/api/interceptors/compose.test.ts
+++ b/test/domains/api/interceptors/compose.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { FetchHook } from 'ofetch'
+import { attachInterceptors, composeHook, getInterceptors } from '../../../../src/runtime/domains/api/interceptors/compose'
+
+const noop: FetchHook = () => {}
+
+function makeInterceptors() {
+  return {
+    onRequest: vi.fn() as unknown as FetchHook,
+    onResponse: vi.fn() as unknown as FetchHook,
+    onResponseError: vi.fn() as unknown as FetchHook
+  }
+}
+
+describe('composeHook', () => {
+  it('用户未传钩子返回 undefined（保持实例 default）', () => {
+    expect(composeHook(noop, undefined)).toBeUndefined()
+  })
+
+  it('用户传单函数返回 [movk, user]，movk 在前', () => {
+    const user: FetchHook = () => {}
+    const result = composeHook(noop, user)
+    expect(result).toEqual([noop, user])
+    expect(result?.[0]).toBe(noop)
+  })
+
+  it('用户传数组返回 [movk, ...users]', () => {
+    const a: FetchHook = () => {}
+    const b: FetchHook = () => {}
+    const result = composeHook(noop, [a, b])
+    expect(result).toEqual([noop, a, b])
+    expect(result?.[0]).toBe(noop)
+  })
+})
+
+describe('attachInterceptors / getInterceptors', () => {
+  it('往返读取挂载的拦截器', () => {
+    const instance = (() => {}) as never
+    const interceptors = makeInterceptors()
+    attachInterceptors(instance, interceptors)
+    expect(getInterceptors(instance)).toBe(interceptors)
+  })
+
+  it('未挂载时返回 undefined', () => {
+    const instance = (() => {}) as never
+    expect(getInterceptors(instance)).toBeUndefined()
+  })
+
+  it('挂载的符号键不可枚举', () => {
+    const instance = (() => {}) as never
+    attachInterceptors(instance, makeInterceptors())
+    expect(Object.keys(instance)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## 问题

`useApiFetch` 中传入自定义 `onResponse`，期望按文档契约拿到**已解包**的 `response._data`，实际拿到原始信封 `{ code, message, data }`。

## 根因

`useApiFetch` 把用户 `onResponse` 透传给 `useFetch`，最终到达 `$api` 实例的**单次调用** options。ofetch（已装 1.5.1 与 2.0.0-alpha.3 两版本一致）在 `resolveFetchOptions` 用 `{ ...defaults, ...input }` 合并 —— **不做拦截器数组合并**。于是用户钩子**整体覆盖** movk 内置拦截器，该次请求：

- 不解包（`_data` 保留原始信封）
- 不做业务码校验
- 不弹 toast、不派发 `movk:api:*` hook
- 传 `onRequest`/`onResponseError` 还会静默关掉认证头注入等内置逻辑

附带：ofetch 的 `onResponse` 忽略返回值，`return response._data?.data ?? []` 本就无效。

## 改动

- 新增 `compose.ts`：用内部符号把每端点内置拦截器挂到 `$fetch` 实例；`composeHook(movk, user)` 在用户传钩子时返回 `[movk, ...user]`（内置先跑），未传返回 `undefined`（不覆盖实例 default）。
- `api.factory.ts`：保留三段拦截器引用并 `attachInterceptors` 到实例（含 `$api.use(endpoint)` 与回落 default 路径）。
- `useApiFetch.ts`：仅对用户实际传入的钩子覆写为组合数组，过滤 `undefined` 键后再传 `useFetch`；同步修正 JSDoc。
- `4.use-api-fetch.md`：强化 `onResponse` 说明（内置先执行、`_data` 已解包、仅业务成功触发、返回值被忽略、变形用 `transform`）。

## 修复后契约

内置拦截器先执行 → 用户 `onResponse` 拿到已解包 `_data`，仅业务成功时触发；认证/业务校验/toast 永不被用户钩子误关。

## 测试

- 新增 `test/domains/api/interceptors/compose.test.ts`、`test/composables/useApiFetch.test.ts`（10 例）。
- `pnpm test` 全量 225 例通过；`pnpm lint` 干净；`pnpm typecheck` 退出码 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)