### PR TITLE
fix(auto-form): 修复 controlProps 在消费端丢失类型提示

### DIFF
--- a/src/runtime/domains/auto-form/controls.ts
+++ b/src/runtime/domains/auto-form/controls.ts
@@ -1,7 +1,22 @@
 import type { IsComponent } from '@movk/core'
 import type { AutoFormControl, _Unset } from '../../types/auto-form/controls'
 import type {
+  CheckboxGroupProps, CheckboxGroupSlots,
+  CheckboxProps, CheckboxSlots,
+  FileUploadProps, FileUploadSlots,
+  InputDateProps, InputDateSlots,
+  InputMenuProps, InputMenuSlots,
+  InputNumberProps, InputNumberSlots,
   InputProps, InputSlots,
+  InputTagsProps, InputTagsSlots,
+  InputTimeProps, InputTimeSlots,
+  ListboxProps, ListboxSlots,
+  PinInputProps, PinInputSlots,
+  RadioGroupProps, RadioGroupSlots,
+  SelectMenuProps, SelectMenuSlots,
+  SelectProps, SelectSlots,
+  SliderProps,
+  SwitchProps, SwitchSlots,
   TextareaProps, TextareaSlots
 } from '@nuxt/ui'
 import type { CalendarDateControlProps } from '../../types/components/date-picker'
@@ -92,15 +107,54 @@ const DEFAULT_CONTROL_COMPONENTS = {
 
 type DefaultControlComponents = typeof DEFAULT_CONTROL_COMPONENTS
 
+/** 本地 .vue 控件：组件类型在声明发射期可解析，controlProps 由组件推导 */
+type LocalControlKey
+  = 'calendarDate'
+    | 'withClear' | 'withPasswordToggle' | 'withCopy'
+    | 'withCharacterLimit' | 'withFloatingLabel' | 'asPhoneNumberInput'
+    | 'colorChooser' | 'slideVerify' | 'pillGroup'
+
+/**
+ * Nuxt UI 控件的 `[props, slots]` 类型登记表。
+ *
+ * `#components` 在模块声明发射期无法解析，`U*` 组件类型会退化为 `any`，
+ * 使 `controlProps` / `controlSlots` 在消费端失去类型提示；此处显式登记以绕开组件推导。
+ */
+interface NuxtUIControlTypes {
+  string: [InputProps, InputSlots]
+  number: [InputNumberProps, InputNumberSlots]
+  boolean: [CheckboxProps, CheckboxSlots]
+  enum: [SelectProps, SelectSlots]
+  file: [FileUploadProps, FileUploadSlots]
+  inputDate: [InputDateProps, InputDateSlots]
+  inputTime: [InputTimeProps, InputTimeSlots]
+  textarea: [TextareaProps, TextareaSlots]
+  switch: [SwitchProps, SwitchSlots]
+  slider: [SliderProps, _Unset]
+  selectMenu: [SelectMenuProps, SelectMenuSlots]
+  inputMenu: [InputMenuProps, InputMenuSlots]
+  checkboxGroup: [CheckboxGroupProps, CheckboxGroupSlots]
+  radioGroup: [RadioGroupProps, RadioGroupSlots]
+  inputTags: [InputTagsProps, InputTagsSlots]
+  pinInput: [PinInputProps, PinInputSlots]
+  listbox: [ListboxProps, ListboxSlots]
+}
+
+/** 约束为 never；有未归类控件时此处直接报错 */
+type _AssertNever<T extends never> = T
+
+// 新增控件必须二选一归类：Nuxt UI 控件登记进 NuxtUIControlTypes，本地 .vue 控件登记进 LocalControlKey
+type _AssertControlsClassified = _AssertNever<
+  Exclude<keyof DefaultControlComponents, keyof NuxtUIControlTypes | LocalControlKey>
+>
+
 type DefaultControlMap = {
   readonly [K in keyof DefaultControlComponents]:
-  K extends 'string'
-    ? AutoFormControl<typeof UInput, InputProps, InputSlots>
-    : K extends 'textarea'
-      ? AutoFormControl<typeof UTextarea, TextareaProps, TextareaSlots>
-      : K extends 'calendarDate'
-        ? AutoFormControl<DefaultControlComponents[K], CalendarDateControlProps>
-        : AutoFormControl<DefaultControlComponents[K]>
+  K extends keyof NuxtUIControlTypes
+    ? AutoFormControl<DefaultControlComponents[K], NuxtUIControlTypes[K][0], NuxtUIControlTypes[K][1]>
+    : K extends 'calendarDate'
+      ? AutoFormControl<DefaultControlComponents[K], CalendarDateControlProps>
+      : AutoFormControl<DefaultControlComponents[K]>
 }
 
 export const DEFAULT_CONTROLS: DefaultControlMap

--- a/src/runtime/types/auto-form/zod-factory.ts
+++ b/src/runtime/types/auto-form/zod-factory.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod'
+import type { VNodeProps } from 'vue'
 import type { CalendarDate, Time } from '@internationalized/date'
 import type {
   ComponentProps,
@@ -41,8 +42,16 @@ type ExtractLayoutShape<S extends Record<string, any>>
     ? LayoutRestShape<S> & LayoutFieldShape<S>
     : S
 
+// vue 注入的 VNode 级 props（key / ref / onVnode*）不属于控件配置面，剔除避免污染补全
 type StrictComponentProps<C extends IsComponent> = {
-  [K in keyof ComponentProps<C> as {} extends Record<K, unknown> ? never : K]: ComponentProps<C>[K]
+  [K in keyof ComponentProps<C> as K extends keyof VNodeProps
+    ? never
+    : {} extends Record<K, unknown> ? never : K]: ComponentProps<C>[K]
+}
+
+/** 控件事件监听通道；回调由 enhanceEventProps 追加字段上下文作为末位参数 */
+type ControlEventProps = {
+  [K in `on${string}`]?: (...args: any[]) => void
 }
 
 type StrictComponentSlots<C extends IsComponent>
@@ -53,8 +62,23 @@ type ControlKey<TControls extends AutoFormControls> = Extract<KnownKeys<TControl
 type ControlEntryByKey<TControls extends AutoFormControls, K extends string>
   = K extends keyof TControls ? TControls[K] : never
 
+type _IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : never
+
+/**
+ * 单一字面量放宽、多成员联合保留。
+ *
+ * Nuxt UI 的 props 泛型默认值偏窄（`M extends boolean = false`、`VK = 'value'`），
+ * 不放宽会让 `multiple: true` 之类的合法取值报错；而 `size` / `color` / `orientation`
+ * 这类真实字面量联合必须原样保留，否则失去补全。
+ */
+type _WidenNarrow<T>
+  = IsAny<T> extends true ? T
+    : [NonNullable<T>] extends [never] ? unknown
+        : _IsUnion<NonNullable<T>> extends true ? T
+          : WidenLiteral<T>
+
 type _WidenForFactory<T> = {
-  [K in keyof T]+?: WidenLiteral<T[K]>
+  [K in keyof T]+?: _WidenNarrow<T[K]>
 }
 
 type _IsUnsetLike<P>
@@ -65,7 +89,9 @@ type _IsUnsetLike<P>
               : false
 
 type ResolveControlProps<C extends IsComponent, P>
-  = _IsUnsetLike<P> extends true ? StrictComponentProps<C> : Prettify<_WidenForFactory<P> & {}>
+  = _IsUnsetLike<P> extends true
+    ? StrictComponentProps<C>
+    : Prettify<_WidenForFactory<P> & {}> & ControlEventProps
 
 type ExtractControlProps<T> = T extends AutoFormControl<infer C, infer P, any>
   ? ResolveControlProps<C, P>


### PR DESCRIPTION
nuxt-module-build 生成 d.ts 时无法解析 #components，从中导入的 U* 组件在 dist 声明里退化为 any，controlProps 经 FallbackToRecordIfEmpty 静默兜底成 Record<string, unknown>。此前仅 string/textarea/calendarDate 显式登记了 props 类型，其余控件（selectMenu 等）在消费端完全没有补全。

- 新增 NuxtUIControlTypes 显式登记 17 个 Nuxt UI 控件的 [Props, Slots]， 绕开组件推导；配 _AssertControlsClassified 断言，新增控件漏登记即报错
- StrictComponentProps 剔除 keyof VNodeProps，消除 key/ref/onVnode* 噪声
- _WidenForFactory 改用 _WidenNarrow：仅放宽单一字面量（Nuxt UI 泛型默认值 偏窄，不放宽会让 multiple: true 报错），保留 size/color/variant 等多成员 联合以维持补全
- 保留 on${string} 事件通道，回调由 enhanceEventProps 追加字段上下文