### PR TITLE
fix(form-control): 显式标注 useFieldControl 返回类型修复声明发射报错

### DIFF
--- a/src/runtime/utils/form-control.ts
+++ b/src/runtime/utils/form-control.ts
@@ -1,3 +1,4 @@
+import type { ComputedRef } from 'vue'
 import { computed, inject } from 'vue'
 import {
   formBusInjectionKey,
@@ -67,19 +68,30 @@ type FieldControlProps = {
   disabled?: boolean
 }
 
+type FieldSize<T extends FieldControlProps> = NonNullable<T['size']> | undefined
+type FieldColor<T extends FieldControlProps> = NonNullable<T['color']> | 'error' | undefined
+
+// 显式标注返回类型：直接展开 useFormField 会让推断结果引用 @vueuse/shared 的
+// UseDebounceFnReturn，声明发射期报 TS2883（不可移植）。
+type FieldControl<T extends FieldControlProps> =
+  Omit<ReturnType<typeof useFormField<T>>, 'size' | 'color' | 'disabled'> & {
+    size: ComputedRef<FieldSize<T>>
+    disabled: ComputedRef<boolean>
+    color: ComputedRef<FieldColor<T>>
+    fieldGroupSize: ReturnType<typeof useFieldGroup<T>>['size']
+    fieldGroupOrientation: ReturnType<typeof useFieldGroup<T>>['orientation']
+  }
+
 // 字段控件型组件统一入口：聚合 useFormField + useFieldGroup，
 // 解决 size/disabled/color 三个继承计算的重复样板。
-export function useFieldControl<T extends FieldControlProps>(props: T) {
-  type FieldSize = NonNullable<T['size']> | undefined
-  type FieldColor = NonNullable<T['color']> | 'error' | undefined
-
+export function useFieldControl<T extends FieldControlProps>(props: T): FieldControl<T> {
   // as never：Nuxt UI 的 useFormField/useFieldGroup 要求 props 满足其内部 Props 形状，这里用泛型 T 转发实际 props，必须绕过类型校验
   const formField = useFormField<T>(props as never)
   const fieldGroup = useFieldGroup<T>(props as never)
 
-  const size = computed<FieldSize>(() => (fieldGroup.size.value || formField.size.value) as FieldSize)
+  const size = computed<FieldSize<T>>(() => (fieldGroup.size.value || formField.size.value) as FieldSize<T>)
   const disabled = computed(() => formField.disabled.value ?? props.disabled ?? false)
-  const color = computed<FieldColor>(() => (formField.color.value ?? props.color) as FieldColor)
+  const color = computed<FieldColor<T>>(() => (formField.color.value ?? props.color) as FieldColor<T>)
 
   return {
     ...formField,


### PR DESCRIPTION
直接展开 useFormField 返回值会让推断结果引用 @vueuse/shared 的 UseDebounceFnReturn，指向 pnpm 虚拟目录下的不可移植路径，构建时 mkdist 生成 d.ts 报 TS2883。

新增 FieldControl 类型，用 Omit<ReturnType<typeof useFormField<T>>> 承接展开部分并交叉覆盖 size/disabled/color 与 fieldGroup 字段，使 d.ts 仅引用已 import 的 @nuxt/ui/composables/useFormField。